### PR TITLE
Update typo in retail cart scenario

### DIFF
--- a/content/scenarios/Retail Cart/_index.en.md
+++ b/content/scenarios/Retail Cart/_index.en.md
@@ -12,7 +12,7 @@ An online retail store has asked you to design their data storage layer and NoSQ
 - Items have the following: *AccountID*, *Status* (`ACTIVE`/`SAVED`/`PURCHASED`), *CreateTimestamp*, & *ItemSKU* - (Total size is < 1 KB)
 - When a user logs in they view the active items in their cart – organized by most recently added.
 - Users can view items that they have saved for later – organized by most recently saved items.
-- Users can view items that they have purchased – also organized by most purchased saved items.
+- Users can view items that they have purchased – also organized by most recently purchased items.
 - Product teams have the ability to regularly query across all users to identify the users that have a specific product either `ACTIVE`, `SAVED`, or `PURCHASED`.
 - The Business Intelligence team needs to run a number of ad hoc complex queries against the dataset to create weekly and monthly reports.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
@sbol-coolblue has a PR that I believe he meant to make on our repo. I'm making one here, for him.
>During DynamoDB Days in Amsterdam we ran into a small textual issue with the Cart scenario => "most purchased saved items" should have been "most recently purchased items".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
