### PR TITLE
Fixed help message for --citydept argument of query_city_dept.py

### DIFF
--- a/design-patterns/query_city_dept.py
+++ b/design-patterns/query_city_dept.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("table", help="table name")
     parser.add_argument("state", help="state name")
-    parser.add_argument("--citydept", help="begin of city and dept in the format city:dept, examples, Sea or Seattle:Dev")
+    parser.add_argument("--citydept", help="begin of city and dept in the format city#dept, examples, Sea or Seattle#Dev")
     args = parser.parse_args()
 
     tableName = args.table


### PR DESCRIPTION
*Description of changes:*
A typo was found in `query_city_dept.py` which states that arguments provided via `--citydept` should match the format `city:dept`. This PR changes the instructions for the `--citydept` argument to align with the expected syntax of `city#dept`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
