### PR TITLE
Fix ConditionExpression when joining a game

### DIFF
--- a/content/game-player-data/join-games/Step1.en.md
+++ b/content/game-player-data/join-games/Step1.en.md
@@ -55,7 +55,7 @@ def join_game_for_user(game_id, username):
                             "SK": { "S": "#METADATA#{}".format(game_id) },
                         },
                         "UpdateExpression": "SET people = people + :p",
-                        "ConditionExpression": "people <= :limit",
+                        "ConditionExpression": "people < :limit",
                         "ExpressionAttributeValues": {
                             ":p": { "N": "1" },
                             ":limit": { "N": "50" }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The expression `people <= :limit` allows 51 people to join a game instead of 50. This pull request changes the ConditionExpression to only allow 50 people.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
