### PR TITLE
Changed to rel link to fix build bug

### DIFF
--- a/content/hands-on-labs/rdbms-migration/migration-chapter00.en.md
+++ b/content/hands-on-labs/rdbms-migration/migration-chapter00.en.md
@@ -12,7 +12,8 @@ There are two CloudFormation templates used in this exercise which will deploy f
 CloudFormation Template1 Resources:
   - OnPrem VPC: Source VPC will represent an on-premise source environment in the N. Virginia region. This VPC will host source MySQL database on Amazon EC2
   - Amazon EC2 MySQL Database: Amazon EC2 Amazon Linux 2 AMI with MySQL installed and running
-  - Load IMDb dataset: The template will create IMDb database on MySQL and load IMDb public dataset files into database. You can learn more about IMDb dataset inside [Explore Source Model](/hands-on-labs/rdbms-migration/migration-chapter03.html)
+  - Load IMDb dataset: The template will create IMDb database on MySQL and load IMDb public dataset files into database. You can learn more about IMDb dataset inside [Explore Source Model]({{< relref "/hands-on-labs/rdbms-migration/migration-chapter03.en.md" >}} "Explore Source Model")
+
 
 CloudFormation Template2 Resources:
   - DMS VPC:  Migration VPC on in the N. Virginia region. This VPC will host DMS replication instance.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
on [this page](https://amazon-dynamodb-labs.com/hands-on-labs/rdbms-migration/migration-chapter00.html) the build system is giving a localhost link instead of a relative link. This PR attempts to fix this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
