### PR TITLE
updates to instructions to map with AWS-run event accounts

### DIFF
--- a/content/design-patterns/setup/Step1.en.md
+++ b/content/design-patterns/setup/Step1.en.md
@@ -5,12 +5,12 @@ weight = 10
 #TODO mod-xxx is not the same name when running in EC2
 +++
 
-1. Once you've gained access to the AWS Management Console for the lab, double check the region is correct and the TeamRole is selected.
-1. In the services search bar, search for Systems Manager and click on it to open the AWS Systems Manager section of the AWS Management Console.
-1. In the AWS Systems Manager console, locate the menu in the left, identify the section "Node Management" and select "Session Manager" from the list.
-1. Choose "Start session" to launch a shell session.
-1. Click the radio button to select the EC2 instance for the lab. If you see no instance, wait a few minutes and then click refresh. Wait until the ec2 instance beginning with name `mod-XXXXXXXXXXXXXXXX` is available before continuing.
-1. Click in the Start Session button (This action will open a new tab in your browser with a new black shell).
+1. Once you've gained access to the AWS Management Console for the lab, double check the region is correct and one of **TeamRole** OR **WSParticipantRole** appears on the top right of the console.
+1. In the services search bar, search for **Systems Manager** and click on it to open the AWS Systems Manager section of the AWS Management Console.
+1. In the AWS Systems Manager console, locate the menu in the left, identify the section **Node Management** and select **Session Manager** from the list.
+1. Choose **Start session** to launch a shell session.
+1. Click the radio button to select the EC2 instance for the lab. If you see no instance, wait a few minutes and then click refresh. Wait until an ec2 instance with name of `mod-XXXXXXXXXXXXXXXX` OR `ddb` is available before continuing. You will see only one of the two names.
+1. Click in the **Start Session** button (This action will open a new tab in your browser with a new black shell).
 1. In the new black shell, switch to the ec2-user account by running `sudo su - ec2-user`
    ```bash
    sudo su - ec2-user

--- a/content/event-driven-architecture/ex3fixbugs/Step3.en.md
+++ b/content/event-driven-architecture/ex3fixbugs/Step3.en.md
@@ -26,6 +26,11 @@ pip3 install --user boto3
 
 Now, you can copy the code below into a file, give it a descriptive name (e.g. `frontend.py`) and run it (`python3 frontend.py`). You should see the current aggregates from the `AggregationTable`, with new messages coming in every 60 seconds!
 
+{{% notice info %}}
+Edit the script to update the correct region value of **REGION_NAME** as per the region you are running the lab in. Use the value in **Code** from [AWS Docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions).
+For example, for Ireland, enter **eu-west-1**.
+{{% /notice %}}
+
 ```python
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0

--- a/content/hands-on-labs/setup/prerequisites.en.md
+++ b/content/hands-on-labs/setup/prerequisites.en.md
@@ -13,9 +13,9 @@ You can use your own account, or an account provided through Event Engine as par
 
 ### Account setup
 
-#### Using an account provided through Event Engine
+#### Using an account provided to you by your lab instructor
 
-If you are running this workshop as part of an Event Engine lab, please log into the console using [this link](https://dashboard.eventengine.run/) and enter the hash provided to you as part of the workshop. In event engine, the Cloud9 instance should be made in your account. Please open the "AWS Cloud9" section of the AWS Management Console in the correct region and look for a lab instance called "DynamoDBC9". 
+If you are running this workshop using a link provided to you by your AWS instructor, please use that link and enter the access-code provided to you as part of the workshop. In the lab AWS account, the Cloud9 instance should already be provisioned. Please open the "AWS Cloud9" section of the AWS Management Console in the correct region and look for a lab instance called **DynamoDBC9**.
 
 #### Using your own AWS account
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- LADV: change to EC2 instance name that appears in Systems Manager
- LEDA: added note to update region name for the optional frontend.py step
- LHOL: update to setup page instructions to include both event engine and workshop studio (AWS-run event platforms)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
