### PR TITLE
LGME: Adding in items.json for lab, fixing build-assets

### DIFF
--- a/.github/scripts/build-assets.py
+++ b/.github/scripts/build-assets.py
@@ -73,6 +73,8 @@ os.chdir(os.path.join(pkg_root, 'game-player-data'))
 with ZipFile('battle-royale.zip', 'w') as workshop_zip:
 	for pyscript in glob.glob('./scripts/*.py'):
 		workshop_zip.write(pyscript)
+	for js_script in glob.glob('./scripts/*.json'):
+		workshop_zip.write(js_script)
 shutil.move(os.path.join(os.getcwd(), 'battle-royale.zip'), os.path.join(dest_root, 'assets', 'battle-royale.zip'))
 
 #Create Global Serverless ZIP

--- a/content/game-player-data/core-usage/Step2.en.md
+++ b/content/game-player-data/core-usage/Step2.en.md
@@ -50,7 +50,7 @@ except Exception as e:
     print(e)
 ```
 
-::alert[Edit **scripts/create_table.py**, set both `ReadCapacityUnits` and `WriteCapacityUnits` to **100** for *battle-royale* table.]{header="Change the capacity units."}
+::alert[Edit **scripts/create_table.py**, set both `ReadCapacityUnits` and `WriteCapacityUnits` to **100** for *battle-royale* table and save the file.]{header="Change the capacity units."}
 
 The preceding script uses the [CreateTable](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html) operation using [Boto 3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html), the AWS SDK for Python. The operation declares two attribute definitions, which are typed attributes to be used in the primary key. Though DynamoDB is [schemaless](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/SQLtoNoSQL.CreateTable.html), you must declare the names and types of attributes that are used for primary keys. The attributes must be included on every item that is written to the table and thus must be specified as you are creating a table.
 

--- a/content/game-player-data/core-usage/Step2.en.md
+++ b/content/game-player-data/core-usage/Step2.en.md
@@ -13,6 +13,7 @@ The code you downloaded in the initial steps include a Python script in the **sc
 
 ```py
 import boto3
+
 dynamodb = boto3.client('dynamodb')
 
 try:
@@ -42,14 +43,14 @@ try:
             "ReadCapacityUnits": 1,
             "WriteCapacityUnits": 1
         }
-        )
-        print("Table 'battle-royale' created successfully.")
+    )
+    print("Table 'battle-royale' created successfully.")
 except Exception as e:
     print("Could not create table. Error:")
     print(e)
 ```
 
-::alert[Edit **scripts/create_table.py**, set both `ReadCapacityUnits` and `WriteCapacityUnits` to **100** for *battle-royale* table.]
+::alert[Edit **scripts/create_table.py**, set both `ReadCapacityUnits` and `WriteCapacityUnits` to **100** for *battle-royale* table.]{header="Change the capacity units."}
 
 The preceding script uses the [CreateTable](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html) operation using [Boto 3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html), the AWS SDK for Python. The operation declares two attribute definitions, which are typed attributes to be used in the primary key. Though DynamoDB is [schemaless](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/SQLtoNoSQL.CreateTable.html), you must declare the names and types of attributes that are used for primary keys. The attributes must be included on every item that is written to the table and thus must be specified as you are creating a table.
 

--- a/content/game-player-data/join-games/Step2.en.md
+++ b/content/game-player-data/join-games/Step2.en.md
@@ -75,8 +75,7 @@ python scripts/start_game.py
 You should see output in your terminal indicating that the game was started successfully.
 
 ```text
-Started game: 
-Game: c6f38a6a-d1c5-4bdf-8468-24692ccc4646   Map: Urban Underground
+Started game: Game: c6f38a6a-d1c5-4bdf-8468-24692ccc4646   Map: Urban Underground
 ```
 
 Try to run the script a second time in your terminal. This time, you should see an error message that indicates you could not start the game. This is because you have already started the game, so the `start_time` attribute exists. As a result, the request failed the conditional check on the entity.

--- a/content/game-player-data/open-games/Step2.en.md
+++ b/content/game-player-data/open-games/Step2.en.md
@@ -60,7 +60,7 @@ except Exception as e:
     print(e)
 ```
 
-::alert[Edit **scripts/add_secondary_index.py**, set both `ReadCapacityUnits` and `WriteCapacityUnits` to **100** for `OpenGamesIndex`.]
+::alert[Edit **scripts/add_secondary_index.py**, set both `ReadCapacityUnits` and `WriteCapacityUnits` to **100** for `OpenGamesIndex`. Then, save the file.]{header="Change the capacity units"}
 
 Whenever attributes are used in a primary key for a table or secondary index, they must be defined in `AttributeDefinitions`. Then, you `Create` a new GSI in the `GlobalSecondaryIndexUpdates` property. For this GSI, you specify the index name, the schema of the primary key, the provisioned throughput, and the attributes you want to project. 
 

--- a/game-player-data/scripts/items.json
+++ b/game-player-data/scripts/items.json
@@ -1,0 +1,835 @@
+{"PK": "USER#lindsay56", "SK": "#METADATA#lindsay56", "address": "8896 Johnson Alley Suite 499\nPhillipsberg, AR 08144", "birthdate": "1920-04-17", "email": "sanchezlaura@yahoo.com", "name": "Daniel Price", "username": "lindsay56"}
+{"PK": "USER#maryharris", "SK": "#METADATA#maryharris", "address": "8434 West Forge Apt. 395\nWest Brenda, HI 36952", "birthdate": "1926-03-09", "email": "charleswayne@gmail.com", "name": "Alyssa Robinson", "username": "maryharris"}
+{"PK": "USER#melissasanchez", "SK": "#METADATA#melissasanchez", "address": "481 Tamara Square Suite 074\nEast Brendanport, MA 64161", "birthdate": "1968-10-11", "email": "elizabethlester@yahoo.com", "name": "Jeffrey Jenkins", "username": "melissasanchez"}
+{"PK": "USER#haleykrystal", "SK": "#METADATA#haleykrystal", "address": "USNS Wallace\nFPO AP 61950", "birthdate": "1910-07-17", "email": "aaron21@hotmail.com", "name": "Miss Christina Taylor", "username": "haleykrystal"}
+{"PK": "USER#mariarichardson", "SK": "#METADATA#mariarichardson", "address": "73286 White Skyway\nEast Susantown, MA 79062", "birthdate": "1966-05-07", "email": "michael72@yahoo.com", "name": "Bradley Gibson", "username": "mariarichardson"}
+{"PK": "USER#kaufmanrobin", "SK": "#METADATA#kaufmanrobin", "address": "4341 Williams Branch\nPort Wendybury, VA 60158", "birthdate": "2014-01-17", "email": "lroth@hotmail.com", "name": "Gloria Simmons", "username": "kaufmanrobin"}
+{"PK": "USER#ubeck", "SK": "#METADATA#ubeck", "address": "68252 Jasmine Motorway Suite 330\nNatashafurt, NC 40495", "birthdate": "1996-12-11", "email": "allisonlane@gmail.com", "name": "Amy Lozano", "username": "ubeck"}
+{"PK": "USER#waltervargas", "SK": "#METADATA#waltervargas", "address": "4706 Cruz Pike Suite 609\nLake Diamondton, ME 16107", "birthdate": "1911-07-01", "email": "robertsbrandon@gmail.com", "name": "Eric Lamb", "username": "waltervargas"}
+{"PK": "USER#sandramorrison", "SK": "#METADATA#sandramorrison", "address": "43193 Hughes Mills\nJohnsonside, MT 06422", "birthdate": "1921-04-11", "email": "nicholas14@hotmail.com", "name": "Michelle Booth", "username": "sandramorrison"}
+{"PK": "USER#louis83", "SK": "#METADATA#louis83", "address": "8380 Danny Path\nHarrisberg, IN 83698", "birthdate": "1937-04-20", "email": "marc78@yahoo.com", "name": "Kelly Smith II", "username": "louis83"}
+{"PK": "USER#miguelparks", "SK": "#METADATA#miguelparks", "address": "797 Klein Pines\nNorth Alexis, SD 86288", "birthdate": "1948-02-01", "email": "isharp@yahoo.com", "name": "Jill Lam", "username": "miguelparks"}
+{"PK": "USER#victoriapatrick", "SK": "#METADATA#victoriapatrick", "address": "0041 David Light Suite 618\nGentryburgh, ND 86236", "birthdate": "1937-09-10", "email": "halekatherine@yahoo.com", "name": "Ronald Dyer", "username": "victoriapatrick"}
+{"PK": "USER#nancy26", "SK": "#METADATA#nancy26", "address": "73551 Wilson Squares Apt. 078\nWest Denise, PA 31293", "birthdate": "1954-09-16", "email": "kelleyjoseph@gmail.com", "name": "Alisha Harrison", "username": "nancy26"}
+{"PK": "USER#heather05", "SK": "#METADATA#heather05", "address": "PSC 3774, Box 0298\nAPO AP 70518", "birthdate": "1919-04-21", "email": "garciaamy@hotmail.com", "name": "Henry Olsen", "username": "heather05"}
+{"PK": "USER#hannah93", "SK": "#METADATA#hannah93", "address": "PSC 4914, Box 5029\nAPO AE 55872", "birthdate": "1990-09-18", "email": "kfranklin@hotmail.com", "name": "Samantha Kidd", "username": "hannah93"}
+{"PK": "USER#maryjoseph", "SK": "#METADATA#maryjoseph", "address": "9608 Romero Brook\nAngelastad, IA 31247", "birthdate": "1947-08-15", "email": "justincombs@yahoo.com", "name": "Ryan Anderson", "username": "maryjoseph"}
+{"PK": "USER#gregorycarlson", "SK": "#METADATA#gregorycarlson", "address": "PSC 6465, Box 2189\nAPO AA 05236", "birthdate": "1948-06-11", "email": "scottmclaughlin@hotmail.com", "name": "Mark Tate", "username": "gregorycarlson"}
+{"PK": "USER#autumnhowell", "SK": "#METADATA#autumnhowell", "address": "9475 Nathaniel Creek Suite 943\nCharlesfurt, OH 15000", "birthdate": "1946-10-01", "email": "tammyhernandez@hotmail.com", "name": "Joann Torres", "username": "autumnhowell"}
+{"PK": "USER#gutierrezjohn", "SK": "#METADATA#gutierrezjohn", "address": "82650 John Cove Apt. 511\nRoystad, NJ 31180", "birthdate": "1919-01-23", "email": "amypena@hotmail.com", "name": "Tiffany Carrillo", "username": "gutierrezjohn"}
+{"PK": "USER#robinsonbenjamin", "SK": "#METADATA#robinsonbenjamin", "address": "4295 Howard Forest\nNorth Christopherfort, LA 34698", "birthdate": "1907-10-12", "email": "lhansen@hotmail.com", "name": "Jason Castillo", "username": "robinsonbenjamin"}
+{"PK": "USER#gonzalezalbert", "SK": "#METADATA#gonzalezalbert", "address": "30613 Evan Lights\nEbonyton, OR 63432", "birthdate": "1971-05-03", "email": "proberts@yahoo.com", "name": "Michael Hanson", "username": "gonzalezalbert"}
+{"PK": "USER#alyssa19", "SK": "#METADATA#alyssa19", "address": "09313 Flores Well Apt. 925\nLake Jack, WA 02536", "birthdate": "1923-08-02", "email": "jeffrey13@gmail.com", "name": "Leah Davis", "username": "alyssa19"}
+{"PK": "USER#phillipsjessica", "SK": "#METADATA#phillipsjessica", "address": "89108 Mccullough Drive Apt. 331\nKylemouth, NE 56203", "birthdate": "1949-09-07", "email": "andrewhaley@gmail.com", "name": "Yolanda Washington", "username": "phillipsjessica"}
+{"PK": "USER#dchavez", "SK": "#METADATA#dchavez", "address": "268 Bolton Center\nSchaeferhaven, AK 35142", "birthdate": "1974-06-26", "email": "ryan30@gmail.com", "name": "Frank Ramsey", "username": "dchavez"}
+{"PK": "USER#matthewday", "SK": "#METADATA#matthewday", "address": "033 Patricia Neck Apt. 370\nLake Blake, SC 69451", "birthdate": "1976-10-21", "email": "sgonzalez@hotmail.com", "name": "Sara Bennett", "username": "matthewday"}
+{"PK": "USER#angelaoliver", "SK": "#METADATA#angelaoliver", "address": "20242 Sanford Parkway\nSouth Robertfort, WA 14634", "birthdate": "1978-11-18", "email": "rebeccavincent@yahoo.com", "name": "Shannon Campbell", "username": "angelaoliver"}
+{"PK": "USER#emccoy", "SK": "#METADATA#emccoy", "address": "629 Colleen Junctions\nJacksonport, DC 80139", "birthdate": "1914-08-23", "email": "atran@hotmail.com", "name": "Kimberly Collier", "username": "emccoy"}
+{"PK": "USER#douglas54", "SK": "#METADATA#douglas54", "address": "30803 Bennett Rue Apt. 674\nLake Catherine, OR 34606", "birthdate": "1974-11-08", "email": "pamela32@hotmail.com", "name": "Tiffany Trevino", "username": "douglas54"}
+{"PK": "USER#jason26", "SK": "#METADATA#jason26", "address": "62745 Landry Neck\nNew Kristi, MT 14476", "birthdate": "1992-03-23", "email": "micheal49@yahoo.com", "name": "Danny Ortiz", "username": "jason26"}
+{"PK": "USER#greenbrandon", "SK": "#METADATA#greenbrandon", "address": "7685 Sierra Forges Suite 511\nKatherineshire, TN 07902", "birthdate": "1989-08-29", "email": "hwebster@yahoo.com", "name": "Shelley Rivera", "username": "greenbrandon"}
+{"PK": "USER#joshuaacosta", "SK": "#METADATA#joshuaacosta", "address": "129 Romero Hill Suite 162\nNathanport, MI 95082", "birthdate": "1987-03-04", "email": "cirwin@gmail.com", "name": "Renee Meza", "username": "joshuaacosta"}
+{"PK": "USER#aguilartracey", "SK": "#METADATA#aguilartracey", "address": "7889 Obrien Junctions\nMelissastad, WA 93261", "birthdate": "1917-03-19", "email": "ncruz@hotmail.com", "name": "Elizabeth Wagner", "username": "aguilartracey"}
+{"PK": "USER#derrick36", "SK": "#METADATA#derrick36", "address": "764 Alicia Greens Apt. 307\nOscarland, LA 65993", "birthdate": "1937-01-04", "email": "banksmark@hotmail.com", "name": "David Johnson", "username": "derrick36"}
+{"PK": "USER#hwolf", "SK": "#METADATA#hwolf", "address": "7537 Michelle River\nWest Natashaborough, CT 10988", "birthdate": "2013-10-15", "email": "cathy08@gmail.com", "name": "Jeffrey Sanchez", "username": "hwolf"}
+{"PK": "USER#brenda89", "SK": "#METADATA#brenda89", "address": "24644 Tracy Viaduct Apt. 767\nEricksonside, CO 90523", "birthdate": "1912-10-28", "email": "marshallbrittney@hotmail.com", "name": "Carrie Garcia", "username": "brenda89"}
+{"PK": "USER#kayla88", "SK": "#METADATA#kayla88", "address": "9162 Benjamin Row\nSouth Kelliberg, ID 04542", "birthdate": "1973-01-09", "email": "jamesisaiah@hotmail.com", "name": "Ebony Rose", "username": "kayla88"}
+{"PK": "USER#jonesbilly", "SK": "#METADATA#jonesbilly", "address": "6755 Brown Spring Suite 382\nEmilybury, GA 27583", "birthdate": "1950-03-09", "email": "moorecurtis@yahoo.com", "name": "Christopher Johnston", "username": "jonesbilly"}
+{"PK": "USER#jasonbarton", "SK": "#METADATA#jasonbarton", "address": "5120 Cooper Course Suite 686\nRonaldbury, NE 42926", "birthdate": "2005-12-11", "email": "smithdavid@yahoo.com", "name": "Debbie Sanchez", "username": "jasonbarton"}
+{"PK": "USER#kristin06", "SK": "#METADATA#kristin06", "address": "931 Jeremy Lights Apt. 369\nNew Richard, IL 93693", "birthdate": "1918-05-19", "email": "arnoldrandy@hotmail.com", "name": "Jason Saunders", "username": "kristin06"}
+{"PK": "USER#cjohnson", "SK": "#METADATA#cjohnson", "address": "4092 James Vista Suite 068\nPort Cynthia, CA 74139", "birthdate": "1908-10-14", "email": "umoss@gmail.com", "name": "Mackenzie Brown", "username": "cjohnson"}
+{"PK": "USER#alvaradonathan", "SK": "#METADATA#alvaradonathan", "address": "345 Brooks Stravenue Apt. 186\nDannyport, CT 64035", "birthdate": "1967-08-18", "email": "jenniferdelgado@hotmail.com", "name": "Michael Ramsey", "username": "alvaradonathan"}
+{"PK": "USER#sharon37", "SK": "#METADATA#sharon37", "address": "9950 Ryan Place\nJamesborough, ND 67644", "birthdate": "1923-11-16", "email": "leegomez@yahoo.com", "name": "Roy Massey", "username": "sharon37"}
+{"PK": "USER#usimpson", "SK": "#METADATA#usimpson", "address": "3499 Holmes Springs\nWest Patriciaburgh, IN 48138", "birthdate": "1982-10-22", "email": "masondavid@gmail.com", "name": "Zachary Drake", "username": "usimpson"}
+{"PK": "USER#qbartlett", "SK": "#METADATA#qbartlett", "address": "50007 Woods Coves Suite 988\nLewisshire, IN 21158", "birthdate": "1919-12-19", "email": "jeremyibarra@yahoo.com", "name": "Elizabeth Woods", "username": "qbartlett"}
+{"PK": "USER#ashleysalas", "SK": "#METADATA#ashleysalas", "address": "5983 Joshua Valley\nJanicemouth, VA 77963", "birthdate": "1968-09-29", "email": "hporter@yahoo.com", "name": "Kyle Wright", "username": "ashleysalas"}
+{"PK": "USER#derrickevans", "SK": "#METADATA#derrickevans", "address": "50071 William Parks Suite 055\nGonzalesfort, WA 57749", "birthdate": "1987-04-13", "email": "williamslori@yahoo.com", "name": "Jessica Henderson MD", "username": "derrickevans"}
+{"PK": "USER#jennifer97", "SK": "#METADATA#jennifer97", "address": "7027 Taylor Trail Suite 836\nLake Melissa, LA 36551", "birthdate": "1918-09-18", "email": "whitedavid@gmail.com", "name": "Keith Howard", "username": "jennifer97"}
+{"PK": "USER#brittany45", "SK": "#METADATA#brittany45", "address": "USNS Webb\nFPO AE 82765", "birthdate": "1976-01-24", "email": "hutchinsonmichelle@yahoo.com", "name": "Nancy Snow", "username": "brittany45"}
+{"PK": "USER#amberodonnell", "SK": "#METADATA#amberodonnell", "address": "29702 Karen Street\nLake Nicholastown, LA 26097", "birthdate": "2012-03-07", "email": "mary52@hotmail.com", "name": "Rhonda Jackson", "username": "amberodonnell"}
+{"PK": "USER#matthewevans", "SK": "#METADATA#matthewevans", "address": "16140 Denise Mission Apt. 840\nLisaland, HI 23378", "birthdate": "1949-12-04", "email": "jennifer23@gmail.com", "name": "Timothy Kramer", "username": "matthewevans"}
+{"PK": "USER#scott45", "SK": "#METADATA#scott45", "address": "369 Eric Turnpike Suite 000\nLake Gerald, CO 54086", "birthdate": "1918-01-31", "email": "stephanie44@hotmail.com", "name": "Anthony Nichols", "username": "scott45"}
+{"PK": "USER#clarkshaun", "SK": "#METADATA#clarkshaun", "address": "3915 Kemp Inlet Suite 796\nHoffmantown, ND 19424", "birthdate": "1925-12-23", "email": "ejohnson@yahoo.com", "name": "Clayton Pena", "username": "clarkshaun"}
+{"PK": "USER#kristine54", "SK": "#METADATA#kristine54", "address": "3443 James Turnpike\nPort Carlburgh, WA 71188", "birthdate": "1966-08-08", "email": "jameshill@yahoo.com", "name": "Jesse Davis", "username": "kristine54"}
+{"PK": "USER#jeremy02", "SK": "#METADATA#jeremy02", "address": "279 Thompson Square Suite 645\nFleminghaven, NJ 96000", "birthdate": "1910-01-19", "email": "krista34@yahoo.com", "name": "Travis Harris", "username": "jeremy02"}
+{"PK": "USER#emma83", "SK": "#METADATA#emma83", "address": "USCGC Horton\nFPO AE 01310", "birthdate": "1938-09-22", "email": "ellisvincent@hotmail.com", "name": "David Jones", "username": "emma83"}
+{"PK": "USER#jenniferlarsen", "SK": "#METADATA#jenniferlarsen", "address": "467 Rogers Spurs Suite 878\nWest Christina, MD 97109", "birthdate": "1919-02-04", "email": "markfields@gmail.com", "name": "Christopher Snyder", "username": "jenniferlarsen"}
+{"PK": "USER#umartin", "SK": "#METADATA#umartin", "address": "70691 Tina Stravenue Suite 763\nEast Perryfurt, MT 86343", "birthdate": "1906-03-05", "email": "vpatel@gmail.com", "name": "Jonathan Castillo", "username": "umartin"}
+{"PK": "USER#johnwilliams", "SK": "#METADATA#johnwilliams", "address": "Unit 5380 Box 4384\nDPO AE 15917", "birthdate": "1951-11-23", "email": "stacymoreno@yahoo.com", "name": "Christina Murphy", "username": "johnwilliams"}
+{"PK": "USER#jennifer32", "SK": "#METADATA#jennifer32", "address": "6747 Rebecca Course\nWest Timothy, MS 18097", "birthdate": "1909-03-10", "email": "mary34@gmail.com", "name": "Gloria Thomas", "username": "jennifer32"}
+{"PK": "USER#sdiaz", "SK": "#METADATA#sdiaz", "address": "1846 Morrison Wall Suite 783\nSouth Kimberly, PA 98733", "birthdate": "1921-08-31", "email": "dennishunter@yahoo.com", "name": "Chad Wells", "username": "sdiaz"}
+{"PK": "USER#staylor", "SK": "#METADATA#staylor", "address": "720 Cabrera Mountain\nLake Megan, MD 28643", "birthdate": "2017-09-29", "email": "cbeltran@hotmail.com", "name": "Shaun James", "username": "staylor"}
+{"PK": "USER#robert98", "SK": "#METADATA#robert98", "address": "550 Simpson Shores\nPort Tracyfort, AZ 66696", "birthdate": "1981-11-16", "email": "riosbrandon@hotmail.com", "name": "Kevin Gillespie", "username": "robert98"}
+{"PK": "USER#scott19", "SK": "#METADATA#scott19", "address": "9439 Dennis Terrace Apt. 156\nNew Reneeburgh, OH 60333", "birthdate": "1973-08-16", "email": "obriencatherine@hotmail.com", "name": "Mindy Moore", "username": "scott19"}
+{"PK": "USER#julie80", "SK": "#METADATA#julie80", "address": "1368 Joseph Knoll Apt. 338\nDanielmouth, PA 63578", "birthdate": "2007-08-25", "email": "dnorman@yahoo.com", "name": "David Thomas", "username": "julie80"}
+{"PK": "USER#mckenziemoreno", "SK": "#METADATA#mckenziemoreno", "address": "81980 Bailey Brooks\nJustinfort, SD 77240", "birthdate": "1908-04-09", "email": "elizabeth13@yahoo.com", "name": "Sierra Murphy", "username": "mckenziemoreno"}
+{"PK": "USER#igaines", "SK": "#METADATA#igaines", "address": "4431 Mathew Circles\nStephentown, NV 61717", "birthdate": "1937-10-13", "email": "greenlucas@gmail.com", "name": "Ryan Johnson", "username": "igaines"}
+{"PK": "USER#tiffany19", "SK": "#METADATA#tiffany19", "address": "74669 Christine Manor\nNorth Micheal, IA 20835", "birthdate": "1976-07-07", "email": "umcgee@hotmail.com", "name": "Diane Schultz", "username": "tiffany19"}
+{"PK": "USER#judyharris", "SK": "#METADATA#judyharris", "address": "47434 Allen Lane\nGreeneside, NH 57740", "birthdate": "1990-09-24", "email": "thompsonchristina@gmail.com", "name": "Amy Leonard", "username": "judyharris"}
+{"PK": "USER#tommyleon", "SK": "#METADATA#tommyleon", "address": "0752 Jennifer Overpass Apt. 253\nSouth Joseph, DC 63267", "birthdate": "1917-07-06", "email": "crystal98@hotmail.com", "name": "Joseph Cruz", "username": "tommyleon"}
+{"PK": "USER#aguilarmartin", "SK": "#METADATA#aguilarmartin", "address": "607 Osborn Brooks Apt. 216\nNorth Angela, UT 81102", "birthdate": "1947-06-04", "email": "dduffy@hotmail.com", "name": "Mary Hampton", "username": "aguilarmartin"}
+{"PK": "USER#usmith", "SK": "#METADATA#usmith", "address": "87276 Robbins Via\nSouth Kenneth, IN 85840", "birthdate": "1964-05-22", "email": "alexandra74@yahoo.com", "name": "Carla Williams", "username": "usmith"}
+{"PK": "USER#kcabrera", "SK": "#METADATA#kcabrera", "address": "95515 Jorge Court\nPowellburgh, LA 43421", "birthdate": "1985-06-17", "email": "alexandriafriedman@yahoo.com", "name": "Jeffrey Perez", "username": "kcabrera"}
+{"PK": "USER#lucasdavis", "SK": "#METADATA#lucasdavis", "address": "80649 Li Route\nNew Sandraborough, MA 01512", "birthdate": "1984-09-06", "email": "reyesmichael@yahoo.com", "name": "Amanda Hatfield", "username": "lucasdavis"}
+{"PK": "USER#austincervantes", "SK": "#METADATA#austincervantes", "address": "Unit 0558 Box 3045\nDPO AA 55142", "birthdate": "1903-07-16", "email": "rachel62@yahoo.com", "name": "Katie Taylor", "username": "austincervantes"}
+{"PK": "USER#ricky31", "SK": "#METADATA#ricky31", "address": "Unit 0942 Box 0030\nDPO AP 31911", "birthdate": "1917-09-29", "email": "rojasthomas@hotmail.com", "name": "Marie Murray", "username": "ricky31"}
+{"PK": "USER#gglover", "SK": "#METADATA#gglover", "address": "40934 Fuller Meadow\nMathisburgh, PA 23585", "birthdate": "1974-04-15", "email": "christopher28@hotmail.com", "name": "Elizabeth Miles", "username": "gglover"}
+{"PK": "USER#hgeorge", "SK": "#METADATA#hgeorge", "address": "882 Stephen Spur Apt. 253\nSantosborough, TN 52632", "birthdate": "2008-03-06", "email": "brian58@gmail.com", "name": "Jeffrey Murphy", "username": "hgeorge"}
+{"PK": "USER#dmoore", "SK": "#METADATA#dmoore", "address": "508 Terrance Ville Apt. 859\nNew Julia, ID 48052", "birthdate": "2014-08-17", "email": "pamelacrane@hotmail.com", "name": "Joshua Brown", "username": "dmoore"}
+{"PK": "USER#roberthill", "SK": "#METADATA#roberthill", "address": "05257 Jones Summit\nCharlestown, ID 53690", "birthdate": "1986-03-18", "email": "gloria91@gmail.com", "name": "Kendra Chase", "username": "roberthill"}
+{"PK": "USER#wknight", "SK": "#METADATA#wknight", "address": "USNV Hill\nFPO AP 75228", "birthdate": "1944-05-08", "email": "patriciaharrington@gmail.com", "name": "Robert Morales", "username": "wknight"}
+{"PK": "USER#fosterandrew", "SK": "#METADATA#fosterandrew", "address": "16074 Richardson Trail Apt. 467\nJoseview, AK 72410", "birthdate": "1979-06-05", "email": "jessicaparks@gmail.com", "name": "John Hensley", "username": "fosterandrew"}
+{"PK": "USER#michael37", "SK": "#METADATA#michael37", "address": "541 Johnson Crest\nStephanieton, FL 68658", "birthdate": "1921-09-09", "email": "sandragarcia@yahoo.com", "name": "Rachael Blake", "username": "michael37"}
+{"PK": "USER#nicholasmartin", "SK": "#METADATA#nicholasmartin", "address": "7065 Chelsea Neck\nPort Kimberly, NV 06801", "birthdate": "1909-04-02", "email": "dscott@gmail.com", "name": "Marie Wong", "username": "nicholasmartin"}
+{"PK": "USER#slawson", "SK": "#METADATA#slawson", "address": "762 Davis Burgs Suite 117\nNew Alexander, NM 15520", "birthdate": "1928-01-29", "email": "yfarrell@hotmail.com", "name": "Maria Hill", "username": "slawson"}
+{"PK": "USER#lindsaypayne", "SK": "#METADATA#lindsaypayne", "address": "7371 Sheppard Common\nTylerberg, RI 85757", "birthdate": "1975-08-27", "email": "mharvey@hotmail.com", "name": "Tracy Owens", "username": "lindsaypayne"}
+{"PK": "USER#sandovalpamela", "SK": "#METADATA#sandovalpamela", "address": "8742 Brown Port\nDenisefort, CT 04611", "birthdate": "1962-05-30", "email": "barryregina@yahoo.com", "name": "Nicholas Pineda", "username": "sandovalpamela"}
+{"PK": "USER#gstanley", "SK": "#METADATA#gstanley", "address": "16722 Annette Cape Apt. 614\nWaltonstad, IA 12497", "birthdate": "1925-07-06", "email": "dkim@hotmail.com", "name": "Jessica Alvarez", "username": "gstanley"}
+{"PK": "USER#bwhitaker", "SK": "#METADATA#bwhitaker", "address": "9671 Larry Streets\nDonnafort, MD 11370", "birthdate": "1963-10-02", "email": "kpeck@gmail.com", "name": "John Chang", "username": "bwhitaker"}
+{"PK": "USER#thomaslarry", "SK": "#METADATA#thomaslarry", "address": "257 Paige Hills Apt. 588\nShepardfort, OR 36567", "birthdate": "1908-10-06", "email": "ccarpenter@yahoo.com", "name": "Jeffrey Payne", "username": "thomaslarry"}
+{"PK": "USER#wcamacho", "SK": "#METADATA#wcamacho", "address": "4877 Ballard Centers Apt. 672\nNew Patricia, IA 87336", "birthdate": "1920-07-11", "email": "ingrampamela@hotmail.com", "name": "Katherine Ruiz", "username": "wcamacho"}
+{"PK": "USER#icole", "SK": "#METADATA#icole", "address": "808 James Street\nEast Christine, OK 37811", "birthdate": "1921-09-01", "email": "nicholscarla@hotmail.com", "name": "Grant Long", "username": "icole"}
+{"PK": "USER#ugonzales", "SK": "#METADATA#ugonzales", "address": "60921 Lisa Springs Suite 115\nSouth Melissa, WA 06156", "birthdate": "1916-07-09", "email": "danielwilliams@hotmail.com", "name": "Steven Mclean", "username": "ugonzales"}
+{"PK": "USER#iherrera", "SK": "#METADATA#iherrera", "address": "77073 Patricia Hill\nHestermouth, IN 29225", "birthdate": "1990-11-14", "email": "pooledawn@yahoo.com", "name": "Victoria Fowler", "username": "iherrera"}
+{"PK": "USER#fuentesnancy", "SK": "#METADATA#fuentesnancy", "address": "7434 Hill Greens Apt. 658\nSouth Johnland, HI 25897", "birthdate": "1942-10-18", "email": "samuelwilliams@yahoo.com", "name": "Adam Aguilar", "username": "fuentesnancy"}
+{"PK": "USER#amymorgan", "SK": "#METADATA#amymorgan", "address": "60668 Coleman Prairie Apt. 374\nParkerchester, CA 77908", "birthdate": "1909-03-28", "email": "moorepatricia@hotmail.com", "name": "Jason Adams", "username": "amymorgan"}
+{"PK": "USER#haleyaguilar", "SK": "#METADATA#haleyaguilar", "address": "68384 Diaz Inlet Apt. 613\nSouth Scott, WY 96521", "birthdate": "1994-06-24", "email": "corey59@yahoo.com", "name": "Jessica Coleman", "username": "haleyaguilar"}
+{"PK": "USER#ahale", "SK": "#METADATA#ahale", "address": "434 Hannah Place\nNew Tracy, TX 52954", "birthdate": "2016-08-21", "email": "robinvalentine@gmail.com", "name": "Juan Patton", "username": "ahale"}
+{"PK": "USER#anastrong", "SK": "#METADATA#anastrong", "address": "998 Preston Locks\nBennettfurt, UT 61705", "birthdate": "1957-05-21", "email": "loganhayden@yahoo.com", "name": "Tracie Harrison", "username": "anastrong"}
+{"PK": "USER#robinsonmonica", "SK": "#METADATA#robinsonmonica", "address": "81131 Brian Turnpike Suite 920\nSouth Henrytown, AK 80216", "birthdate": "1967-01-18", "email": "monica40@yahoo.com", "name": "Heather Kline", "username": "robinsonmonica"}
+{"PK": "USER#johnsonscott", "SK": "#METADATA#johnsonscott", "address": "913 Tonya Harbor\nMalloryside, OH 19478", "birthdate": "2000-08-07", "email": "carmenpennington@gmail.com", "name": "Dr. Joshua Davenport MD", "username": "johnsonscott"}
+{"PK": "USER#victorharper", "SK": "#METADATA#victorharper", "address": "215 Christina Spurs Apt. 381\nJacobsburgh, DC 00611", "birthdate": "1938-06-07", "email": "kenneth28@hotmail.com", "name": "Pedro Baldwin", "username": "victorharper"}
+{"PK": "USER#hbarron", "SK": "#METADATA#hbarron", "address": "712 Charles Plains Apt. 408\nLake Karenside, OR 28513", "birthdate": "2009-09-27", "email": "johnsonelizabeth@gmail.com", "name": "Tammy Jones", "username": "hbarron"}
+{"PK": "USER#jeremyjohnson", "SK": "#METADATA#jeremyjohnson", "address": "PSC 4252, Box 2580\nAPO AA 92671", "birthdate": "1915-04-05", "email": "russellcheyenne@hotmail.com", "name": "Jennifer Marquez", "username": "jeremyjohnson"}
+{"PK": "USER#townsendjohn", "SK": "#METADATA#townsendjohn", "address": "PSC 6332, Box 9184\nAPO AE 92957", "birthdate": "1925-06-01", "email": "hughescourtney@yahoo.com", "name": "Hailey Jennings", "username": "townsendjohn"}
+{"PK": "USER#johnsonwendy", "SK": "#METADATA#johnsonwendy", "address": "5071 Hubbard Cliffs\nEast Lisa, VT 62992", "birthdate": "1931-08-07", "email": "adamsbryan@hotmail.com", "name": "Allison Miller", "username": "johnsonwendy"}
+{"PK": "USER#carl23", "SK": "#METADATA#carl23", "address": "USNS Reed\nFPO AE 22044", "birthdate": "1944-06-07", "email": "jennifervelazquez@yahoo.com", "name": "Adrian Gonzalez", "username": "carl23"}
+{"PK": "USER#mstone", "SK": "#METADATA#mstone", "address": "905 Preston Inlet Suite 999\nRobertfurt, MA 37642", "birthdate": "2000-03-23", "email": "lisaellis@hotmail.com", "name": "Steven Phillips", "username": "mstone"}
+{"PK": "USER#kellercole", "SK": "#METADATA#kellercole", "address": "4907 Brown Villages\nDaniellehaven, HI 71111", "birthdate": "2004-05-21", "email": "cassandrachavez@hotmail.com", "name": "Nicholas Dixon", "username": "kellercole"}
+{"PK": "USER#romerocaitlin", "SK": "#METADATA#romerocaitlin", "address": "6430 David Isle Apt. 789\nJimenezview, NE 78412", "birthdate": "1931-01-06", "email": "john16@yahoo.com", "name": "Mary Frederick", "username": "romerocaitlin"}
+{"PK": "USER#toddmaynard", "SK": "#METADATA#toddmaynard", "address": "6869 Michael Rapid\nSouth Davidfurt, NC 03153", "birthdate": "1976-04-23", "email": "kerry72@hotmail.com", "name": "Andrew Stevenson", "username": "toddmaynard"}
+{"PK": "USER#morgankeith", "SK": "#METADATA#morgankeith", "address": "359 Alan Courts Suite 988\nRonaldstad, OK 60415", "birthdate": "1936-12-11", "email": "hmcdaniel@gmail.com", "name": "Karen Bray", "username": "morgankeith"}
+{"PK": "USER#rachel67", "SK": "#METADATA#rachel67", "address": "51483 Jennifer Alley\nMercadoville, WI 98304", "birthdate": "1919-05-21", "email": "smorales@gmail.com", "name": "Jennifer Gonzalez", "username": "rachel67"}
+{"PK": "USER#robert51", "SK": "#METADATA#robert51", "address": "62875 Steven Run\nMichaelstad, NC 29006", "birthdate": "2018-04-27", "email": "matthew52@gmail.com", "name": "Lisa Miller", "username": "robert51"}
+{"PK": "USER#clarkeheather", "SK": "#METADATA#clarkeheather", "address": "756 Evans Prairie\nBruceborough, AK 24582", "birthdate": "1924-05-15", "email": "singletonmark@gmail.com", "name": "Tim Rice", "username": "clarkeheather"}
+{"PK": "USER#wgregory", "SK": "#METADATA#wgregory", "address": "1600 Berry Canyon Apt. 010\nPort Kevinhaven, FL 03637", "birthdate": "1916-03-13", "email": "billyferguson@hotmail.com", "name": "Andrea Munoz", "username": "wgregory"}
+{"PK": "USER#kellydavid", "SK": "#METADATA#kellydavid", "address": "PSC 2963, Box 9766\nAPO AA 38194", "birthdate": "1968-12-26", "email": "hancockmichael@yahoo.com", "name": "Sean Luna", "username": "kellydavid"}
+{"PK": "USER#philipsingleton", "SK": "#METADATA#philipsingleton", "address": "1620 Alexandra Coves\nWest Jamesview, AL 24924", "birthdate": "1931-12-11", "email": "tmorales@gmail.com", "name": "Joshua Rogers", "username": "philipsingleton"}
+{"PK": "USER#sylviamoreno", "SK": "#METADATA#sylviamoreno", "address": "USS Morales\nFPO AP 85788", "birthdate": "1924-09-04", "email": "joseph65@yahoo.com", "name": "Christine Welch", "username": "sylviamoreno"}
+{"PK": "USER#xvasquez", "SK": "#METADATA#xvasquez", "address": "753 Jacob Ways Suite 064\nSandersmouth, MN 93144", "birthdate": "2013-06-21", "email": "aclark@gmail.com", "name": "Samantha Schneider", "username": "xvasquez"}
+{"PK": "USER#wardmichelle", "SK": "#METADATA#wardmichelle", "address": "Unit 3704 Box 9295\nDPO AE 17091", "birthdate": "1986-09-17", "email": "melissahenderson@yahoo.com", "name": "Courtney Knight", "username": "wardmichelle"}
+{"PK": "USER#eric53", "SK": "#METADATA#eric53", "address": "7993 Henderson Ports Suite 061\nBakerberg, DE 06892", "birthdate": "1962-02-11", "email": "alexandra39@gmail.com", "name": "Shelley Arnold", "username": "eric53"}
+{"PK": "USER#ywyatt", "SK": "#METADATA#ywyatt", "address": "67172 Emily Crescent\nSoniatown, VT 44567", "birthdate": "1964-07-29", "email": "danielswanson@yahoo.com", "name": "William Rollins", "username": "ywyatt"}
+{"PK": "USER#connie13", "SK": "#METADATA#connie13", "address": "00752 Nichols Fort Apt. 504\nWendymouth, NC 05999", "birthdate": "1911-10-19", "email": "donna12@hotmail.com", "name": "Shannon Johnson", "username": "connie13"}
+{"PK": "USER#richardandrews", "SK": "#METADATA#richardandrews", "address": "804 Roberts Manor\nSouth Elizabethville, VA 83067", "birthdate": "1967-10-19", "email": "burkejoseph@gmail.com", "name": "James Matthews", "username": "richardandrews"}
+{"PK": "USER#angela85", "SK": "#METADATA#angela85", "address": "00827 Murphy Station\nPerryton, WI 36229", "birthdate": "1967-04-14", "email": "summerlawson@hotmail.com", "name": "Mark Weaver", "username": "angela85"}
+{"PK": "USER#mayrebecca", "SK": "#METADATA#mayrebecca", "address": "Unit 0860 Box 5170\nDPO AA 19175", "birthdate": "2008-04-24", "email": "stewartjulie@gmail.com", "name": "Jerry Harding", "username": "mayrebecca"}
+{"PK": "USER#schwartzannette", "SK": "#METADATA#schwartzannette", "address": "2368 Garcia Spurs Suite 459\nCrystalshire, KY 71370", "birthdate": "1956-08-16", "email": "keyjanice@gmail.com", "name": "Sydney Morrow", "username": "schwartzannette"}
+{"PK": "USER#richard21", "SK": "#METADATA#richard21", "address": "26257 Michael Vista Suite 408\nEast David, NJ 54299", "birthdate": "1936-07-28", "email": "johnjohnson@gmail.com", "name": "Kenneth Costa", "username": "richard21"}
+{"PK": "USER#joshuaferguson", "SK": "#METADATA#joshuaferguson", "address": "1755 Ballard Roads\nEdwardburgh, KY 21615", "birthdate": "1990-03-10", "email": "ehudson@yahoo.com", "name": "Veronica Burnett", "username": "joshuaferguson"}
+{"PK": "USER#valenzuelajennifer", "SK": "#METADATA#valenzuelajennifer", "address": "17792 Young Glens Suite 612\nJeremychester, HI 82888", "birthdate": "1973-03-13", "email": "terryjohn@gmail.com", "name": "Eric Oconnell", "username": "valenzuelajennifer"}
+{"PK": "USER#rmartinez", "SK": "#METADATA#rmartinez", "address": "USCGC Davis\nFPO AP 45769", "birthdate": "1932-03-25", "email": "hallkelly@gmail.com", "name": "Keith Stephens", "username": "rmartinez"}
+{"PK": "USER#tony22", "SK": "#METADATA#tony22", "address": "4394 Bradley Lake Suite 243\nNew Jessicaland, NV 54647", "birthdate": "1972-04-14", "email": "zgreer@gmail.com", "name": "Mary Owens", "username": "tony22"}
+{"PK": "USER#pgray", "SK": "#METADATA#pgray", "address": "36111 Duarte Street Apt. 794\nNorth Brendaview, OH 27793", "birthdate": "1979-01-16", "email": "andrew48@yahoo.com", "name": "Eric Werner", "username": "pgray"}
+{"PK": "USER#mcampbell", "SK": "#METADATA#mcampbell", "address": "732 Smith Trail Suite 841\nLaurenmouth, ME 89645", "birthdate": "2004-04-01", "email": "bsmith@yahoo.com", "name": "Abigail Jennings", "username": "mcampbell"}
+{"PK": "USER#andersonbrittney", "SK": "#METADATA#andersonbrittney", "address": "0517 Acosta Meadow\nSouth Jeff, AZ 75920", "birthdate": "1973-11-06", "email": "christopher60@hotmail.com", "name": "Stephen Ramirez", "username": "andersonbrittney"}
+{"PK": "USER#jackparks", "SK": "#METADATA#jackparks", "address": "Unit 2709 Box 9471\nDPO AA 84787", "birthdate": "2010-04-18", "email": "andrearodriguez@gmail.com", "name": "Taylor Martin", "username": "jackparks"}
+{"PK": "USER#guzmanfrank", "SK": "#METADATA#guzmanfrank", "address": "02159 Henderson Tunnel Suite 074\nCarolfurt, GA 87389", "birthdate": "1989-12-19", "email": "trevor92@gmail.com", "name": "Ann Smith", "username": "guzmanfrank"}
+{"PK": "USER#millerashlee", "SK": "#METADATA#millerashlee", "address": "0693 Shannon Lights\nJamesburgh, SD 52866", "birthdate": "2002-02-25", "email": "crawfordwilliam@gmail.com", "name": "John Bass", "username": "millerashlee"}
+{"PK": "USER#caseychristian", "SK": "#METADATA#caseychristian", "address": "841 Jason Light Suite 956\nSouth Sydneyport, MA 15992", "birthdate": "1907-01-09", "email": "ginamcbride@yahoo.com", "name": "Andrew Meyer", "username": "caseychristian"}
+{"PK": "USER#qlucero", "SK": "#METADATA#qlucero", "address": "657 Carol Ports Apt. 883\nWilliamside, NM 12600", "birthdate": "1997-05-21", "email": "rebecca70@gmail.com", "name": "Amber Mcintyre DVM", "username": "qlucero"}
+{"PK": "USER#brandon30", "SK": "#METADATA#brandon30", "address": "0371 Mark Brook Suite 485\nNew Jacobshire, NH 97264", "birthdate": "1905-02-09", "email": "theresaschwartz@gmail.com", "name": "James Davis", "username": "brandon30"}
+{"PK": "USER#mbrown", "SK": "#METADATA#mbrown", "address": "2573 Kyle Mountains Apt. 596\nKarenshire, WA 25951", "birthdate": "1987-12-17", "email": "andrea06@hotmail.com", "name": "Jeffrey Coffey", "username": "mbrown"}
+{"PK": "USER#sean79", "SK": "#METADATA#sean79", "address": "8161 Jackson Forest\nJuliehaven, KY 48331", "birthdate": "1927-11-09", "email": "leah02@yahoo.com", "name": "Anthony Mcdonald", "username": "sean79"}
+{"PK": "USER#kellymiller", "SK": "#METADATA#kellymiller", "address": "150 Darlene Road Suite 228\nNorth Andrewside, CT 74918", "birthdate": "1951-09-13", "email": "rogersmichael@gmail.com", "name": "Christopher Mcdonald", "username": "kellymiller"}
+{"PK": "USER#howard47", "SK": "#METADATA#howard47", "address": "3996 Ellis Cliffs\nDanielmouth, OR 95644", "birthdate": "1935-06-16", "email": "christopherwatkins@gmail.com", "name": "Keith Bolton", "username": "howard47"}
+{"PK": "USER#epayne", "SK": "#METADATA#epayne", "address": "92413 Robert Park Apt. 529\nBlackburgh, WV 43284", "birthdate": "1976-03-04", "email": "larry96@hotmail.com", "name": "Stephen Mercer", "username": "epayne"}
+{"PK": "USER#bhernandez", "SK": "#METADATA#bhernandez", "address": "913 Garcia Shoal Suite 254\nBruceland, IL 56766", "birthdate": "1910-03-11", "email": "jamesdaniels@hotmail.com", "name": "Christina Martinez", "username": "bhernandez"}
+{"PK": "USER#kingpatrick", "SK": "#METADATA#kingpatrick", "address": "7363 Williams Plaza\nNew Timothy, SD 32142", "birthdate": "1958-07-19", "email": "perezamanda@gmail.com", "name": "Emily Mccarthy", "username": "kingpatrick"}
+{"PK": "USER#pruiz", "SK": "#METADATA#pruiz", "address": "2650 Gonzalez Lake Suite 892\nStephenfurt, VA 13850", "birthdate": "1998-06-19", "email": "zcordova@yahoo.com", "name": "Rita Carter", "username": "pruiz"}
+{"PK": "USER#baldwinangela", "SK": "#METADATA#baldwinangela", "address": "5821 Charles Crescent\nWest Rebeccaburgh, KS 22115", "birthdate": "1978-07-25", "email": "robert33@hotmail.com", "name": "Katie Cox", "username": "baldwinangela"}
+{"PK": "USER#madelineharrison", "SK": "#METADATA#madelineharrison", "address": "USCGC Jones\nFPO AP 69398", "birthdate": "1956-02-18", "email": "christine82@gmail.com", "name": "Jaclyn Aguilar", "username": "madelineharrison"}
+{"PK": "USER#sdavis", "SK": "#METADATA#sdavis", "address": "35292 Leon Groves\nHernandezchester, IL 10469", "birthdate": "1946-11-12", "email": "zsandoval@gmail.com", "name": "Joseph Decker", "username": "sdavis"}
+{"PK": "USER#ohayes", "SK": "#METADATA#ohayes", "address": "517 Wright Fort\nNew Emma, AZ 57477", "birthdate": "1985-07-28", "email": "thomasdale@yahoo.com", "name": "Eric Ford", "username": "ohayes"}
+{"PK": "USER#dianaclay", "SK": "#METADATA#dianaclay", "address": "03061 Penny Station Suite 881\nMelissaside, AR 65130", "birthdate": "1975-09-23", "email": "lindadominguez@gmail.com", "name": "Joseph Villarreal", "username": "dianaclay"}
+{"PK": "USER#marksmall", "SK": "#METADATA#marksmall", "address": "154 Dylan Lodge\nAngelicamouth, NC 85177", "birthdate": "1954-03-01", "email": "hhampton@yahoo.com", "name": "Melissa Terrell", "username": "marksmall"}
+{"PK": "USER#floresmonica", "SK": "#METADATA#floresmonica", "address": "Unit 1222 Box 9478\nDPO AE 49912", "birthdate": "2016-04-09", "email": "rebeccajones@hotmail.com", "name": "Kristin Robinson", "username": "floresmonica"}
+{"PK": "USER#kevinsmith", "SK": "#METADATA#kevinsmith", "address": "39690 Figueroa Burg Suite 009\nNorth Thomasfort, NY 19331", "birthdate": "1933-04-03", "email": "rmahoney@yahoo.com", "name": "Marcus Nash", "username": "kevinsmith"}
+{"PK": "USER#sototheresa", "SK": "#METADATA#sototheresa", "address": "687 Jeffrey Loop Suite 838\nPort Ryanview, FL 19590", "birthdate": "1985-01-03", "email": "kathleenmedina@gmail.com", "name": "Adam Marks", "username": "sototheresa"}
+{"PK": "USER#hshort", "SK": "#METADATA#hshort", "address": "704 Joe Well Suite 733\nWest Antonio, NC 69707", "birthdate": "1973-06-15", "email": "kristen69@yahoo.com", "name": "Dalton Wilson", "username": "hshort"}
+{"PK": "USER#stevendavis", "SK": "#METADATA#stevendavis", "address": "Unit 6887 Box 0840\nDPO AE 40786", "birthdate": "2000-12-18", "email": "vangnoah@yahoo.com", "name": "Richard Peterson", "username": "stevendavis"}
+{"PK": "USER#iwilkinson", "SK": "#METADATA#iwilkinson", "address": "56924 Kelly Mount Apt. 734\nNew Maryberg, TN 64894", "birthdate": "1921-10-01", "email": "grimesjoyce@hotmail.com", "name": "Danielle Williams", "username": "iwilkinson"}
+{"PK": "USER#gregory96", "SK": "#METADATA#gregory96", "address": "64881 Lisa Harbor\nEast Gabriellaport, MT 74556", "birthdate": "1918-12-15", "email": "makayla20@gmail.com", "name": "John Strong", "username": "gregory96"}
+{"PK": "USER#megandorsey", "SK": "#METADATA#megandorsey", "address": "05149 Hughes Forks Suite 534\nAmyshire, SD 47905", "birthdate": "1958-06-21", "email": "laurenjenkins@hotmail.com", "name": "Todd Munoz", "username": "megandorsey"}
+{"PK": "USER#kingmelissa", "SK": "#METADATA#kingmelissa", "address": "9762 Ortiz Viaduct\nAndretown, SC 59455", "birthdate": "1981-10-12", "email": "colleencarpenter@hotmail.com", "name": "Jessica Jones", "username": "kingmelissa"}
+{"PK": "USER#nicholas28", "SK": "#METADATA#nicholas28", "address": "41200 Harris Inlet Suite 104\nClarkeshire, MT 40750", "birthdate": "1966-04-21", "email": "gregorygonzalez@gmail.com", "name": "Stephanie Johnson", "username": "nicholas28"}
+{"PK": "USER#matthew09", "SK": "#METADATA#matthew09", "address": "11200 Andrews Landing\nLake Sara, AL 62350", "birthdate": "1977-10-31", "email": "cruzmegan@hotmail.com", "name": "Joshua Henry", "username": "matthew09"}
+{"PK": "USER#ebarton", "SK": "#METADATA#ebarton", "address": "500 Shawn Hills\nMelissastad, NH 91109", "birthdate": "1922-08-21", "email": "richardwilliams@gmail.com", "name": "Latasha Ward", "username": "ebarton"}
+{"PK": "USER#mary60", "SK": "#METADATA#mary60", "address": "72353 Glenn Landing\nNew Andrea, IN 52925", "birthdate": "1944-06-22", "email": "emilyneal@gmail.com", "name": "Dr. Sheryl Gross MD", "username": "mary60"}
+{"PK": "USER#anthony67", "SK": "#METADATA#anthony67", "address": "04675 Barber Viaduct\nSouth Johnshire, OR 59018", "birthdate": "1920-07-20", "email": "heather73@gmail.com", "name": "Daniel Rodgers", "username": "anthony67"}
+{"PK": "USER#robertwood", "SK": "#METADATA#robertwood", "address": "PSC 5130, Box 3578\nAPO AP 17275", "birthdate": "2012-02-09", "email": "dannyharris@gmail.com", "name": "Holly Combs", "username": "robertwood"}
+{"PK": "USER#zacharyreed", "SK": "#METADATA#zacharyreed", "address": "593 Stevens Ridge Apt. 664\nSmithberg, NE 11315", "birthdate": "1969-11-05", "email": "jared96@yahoo.com", "name": "Kayla Murphy", "username": "zacharyreed"}
+{"PK": "USER#figueroaaaron", "SK": "#METADATA#figueroaaaron", "address": "0212 Stephen Isle Suite 075\nEast Thomasport, WI 36642", "birthdate": "1938-07-26", "email": "bmarquez@yahoo.com", "name": "Troy Weeks", "username": "figueroaaaron"}
+{"PK": "USER#tracyhodge", "SK": "#METADATA#tracyhodge", "address": "4636 Amanda Crossroad\nPort Erikachester, IL 99632", "birthdate": "1986-10-04", "email": "david28@gmail.com", "name": "Monica Dixon", "username": "tracyhodge"}
+{"PK": "USER#parkeranthony", "SK": "#METADATA#parkeranthony", "address": "67735 Harrison Fort Apt. 080\nSouth Ashley, MD 50864", "birthdate": "1996-08-10", "email": "beanjessica@hotmail.com", "name": "Tammie Swanson", "username": "parkeranthony"}
+{"PK": "USER#atkinscarolyn", "SK": "#METADATA#atkinscarolyn", "address": "2338 Martin Harbor\nAaronburgh, OH 57785", "birthdate": "1919-03-18", "email": "rogermitchell@gmail.com", "name": "Jennifer Glover", "username": "atkinscarolyn"}
+{"PK": "USER#douglasgloria", "SK": "#METADATA#douglasgloria", "address": "USS Harper\nFPO AA 82870", "birthdate": "2004-03-16", "email": "parkerconnie@hotmail.com", "name": "Carolyn Roberts", "username": "douglasgloria"}
+{"PK": "USER#gregoryreynolds", "SK": "#METADATA#gregoryreynolds", "address": "99297 Duarte Groves Suite 984\nJonathanville, TN 01574", "birthdate": "1969-12-04", "email": "philipstein@gmail.com", "name": "Kimberly Snow", "username": "gregoryreynolds"}
+{"PK": "USER#prodriguez", "SK": "#METADATA#prodriguez", "address": "815 William Port Suite 553\nLake Holly, KS 67840", "birthdate": "1989-09-30", "email": "carolynnguyen@hotmail.com", "name": "Tara Craig", "username": "prodriguez"}
+{"PK": "USER#thomas79", "SK": "#METADATA#thomas79", "address": "Unit 8929 Box 5827\nDPO AE 25338", "birthdate": "1932-12-28", "email": "kimberlyduncan@yahoo.com", "name": "Timothy Dawson", "username": "thomas79"}
+{"PK": "USER#qcruz", "SK": "#METADATA#qcruz", "address": "5730 Jessica Track Apt. 074\nSouth Alexander, TN 25698", "birthdate": "1976-08-03", "email": "robert60@yahoo.com", "name": "Shawn Vazquez", "username": "qcruz"}
+{"PK": "USER#roselaurie", "SK": "#METADATA#roselaurie", "address": "128 Duke Coves Suite 166\nWest Anna, ID 24450", "birthdate": "1903-10-17", "email": "howevanessa@yahoo.com", "name": "Ronald Cook", "username": "roselaurie"}
+{"PK": "USER#colinbutler", "SK": "#METADATA#colinbutler", "address": "09260 Evans Field Suite 177\nOrtizview, OR 99170", "birthdate": "1915-11-08", "email": "carrolljulia@gmail.com", "name": "Nancy Wallace", "username": "colinbutler"}
+{"PK": "USER#kennethrussell", "SK": "#METADATA#kennethrussell", "address": "3088 Sean Estate Apt. 294\nDanielleview, AK 25237", "birthdate": "2017-02-20", "email": "lturner@hotmail.com", "name": "Anthony Clark", "username": "kennethrussell"}
+{"PK": "USER#elloyd", "SK": "#METADATA#elloyd", "address": "USNS Dodson\nFPO AP 93774", "birthdate": "2014-08-13", "email": "webbwilliam@gmail.com", "name": "Evan Moore", "username": "elloyd"}
+{"PK": "USER#rosesandra", "SK": "#METADATA#rosesandra", "address": "4197 Jonathan Highway Suite 946\nPort Donaldmouth, TN 28132", "birthdate": "1983-08-08", "email": "davidholland@gmail.com", "name": "Shawn Wells", "username": "rosesandra"}
+{"PK": "USER#sbrooks", "SK": "#METADATA#sbrooks", "address": "443 Spencer Road\nLake Benjaminberg, NY 49828", "birthdate": "1931-10-02", "email": "estewart@yahoo.com", "name": "John Morris", "username": "sbrooks"}
+{"PK": "USER#ejones", "SK": "#METADATA#ejones", "address": "4538 Steve Pines Apt. 719\nPort Judyport, WY 23266", "birthdate": "1984-06-07", "email": "michaellutz@yahoo.com", "name": "Mark Oneill", "username": "ejones"}
+{"PK": "USER#jerry26", "SK": "#METADATA#jerry26", "address": "74175 Phillips Wells Suite 768\nReedmouth, TN 40223", "birthdate": "1906-11-01", "email": "michele75@hotmail.com", "name": "Kathleen Adams", "username": "jerry26"}
+{"PK": "USER#mclaughlinjeff", "SK": "#METADATA#mclaughlinjeff", "address": "54031 Gregory Crest\nCarlfort, OR 25278", "birthdate": "2003-04-20", "email": "coleveronica@yahoo.com", "name": "Angela Murray", "username": "mclaughlinjeff"}
+{"PK": "USER#grayterri", "SK": "#METADATA#grayterri", "address": "80899 Eric Isle\nRogerfort, VA 61608", "birthdate": "2015-06-11", "email": "christopherhansen@gmail.com", "name": "Brady Moody", "username": "grayterri"}
+{"PK": "USER#alexander03", "SK": "#METADATA#alexander03", "address": "19203 Richard Rue Apt. 656\nDerrickbury, NY 46695", "birthdate": "1951-09-13", "email": "toddbaker@gmail.com", "name": "Alyssa Martin", "username": "alexander03"}
+{"PK": "USER#frederickbradford", "SK": "#METADATA#frederickbradford", "address": "94970 Cruz Mountains\nPort Brian, AL 49598", "birthdate": "1959-11-30", "email": "christopherchristensen@yahoo.com", "name": "Anthony Flores", "username": "frederickbradford"}
+{"PK": "USER#powelltamara", "SK": "#METADATA#powelltamara", "address": "95876 May Springs\nWallsstad, MD 03116", "birthdate": "2016-11-09", "email": "davisjeremiah@gmail.com", "name": "Daniel Lopez", "username": "powelltamara"}
+{"PK": "USER#bentonsharon", "SK": "#METADATA#bentonsharon", "address": "28404 Thompson Crest\nEast Andrea, ME 05195", "birthdate": "1971-10-18", "email": "baileyevans@yahoo.com", "name": "Caroline Harris", "username": "bentonsharon"}
+{"PK": "USER#fsutton", "SK": "#METADATA#fsutton", "address": "346 Howard Station\nStuartfort, GA 23492", "birthdate": "1907-04-19", "email": "murphyamber@yahoo.com", "name": "Charles Taylor", "username": "fsutton"}
+{"PK": "USER#jmiller", "SK": "#METADATA#jmiller", "address": "654 Kristina Roads Suite 490\nWoodsborough, ND 33834", "birthdate": "1955-09-04", "email": "alvarezmary@yahoo.com", "name": "Heidi Lynch", "username": "jmiller"}
+{"PK": "USER#kimberly02", "SK": "#METADATA#kimberly02", "address": "26998 Richard Spur\nAndreatown, TX 46214", "birthdate": "2005-09-06", "email": "madisonstanton@hotmail.com", "name": "Brandon Sanchez", "username": "kimberly02"}
+{"PK": "USER#ralph89", "SK": "#METADATA#ralph89", "address": "USNS Park\nFPO AP 81034", "birthdate": "1920-04-22", "email": "xrobinson@yahoo.com", "name": "Patrick Floyd", "username": "ralph89"}
+{"PK": "USER#ckelley", "SK": "#METADATA#ckelley", "address": "Unit 0336 Box 5225\nDPO AE 47377", "birthdate": "1939-08-01", "email": "kelsey12@gmail.com", "name": "Jonathan Eaton", "username": "ckelley"}
+{"PK": "USER#cpowers", "SK": "#METADATA#cpowers", "address": "714 Keith Prairie Suite 056\nBassfort, MA 54551", "birthdate": "1945-09-11", "email": "vperry@hotmail.com", "name": "Jeffery Combs", "username": "cpowers"}
+{"PK": "USER#jessica61", "SK": "#METADATA#jessica61", "address": "163 Meghan Flats\nDevinport, KY 54859", "birthdate": "1996-01-28", "email": "alexandersummers@hotmail.com", "name": "Megan Pierce", "username": "jessica61"}
+{"PK": "USER#mmitchell", "SK": "#METADATA#mmitchell", "address": "386 Harris Expressway\nNicholastown, MO 66797", "birthdate": "1948-11-27", "email": "mhoward@gmail.com", "name": "Donald Jones", "username": "mmitchell"}
+{"PK": "USER#jackson64", "SK": "#METADATA#jackson64", "address": "62907 Eric Spring Suite 655\nSouth Jennifer, MO 42065", "birthdate": "2014-07-17", "email": "adkinsdillon@gmail.com", "name": "Rebecca Archer", "username": "jackson64"}
+{"PK": "USER#paige47", "SK": "#METADATA#paige47", "address": "986 Anderson Prairie\nJennifermouth, IL 75390", "birthdate": "2018-11-04", "email": "rachel07@yahoo.com", "name": "Travis Grant", "username": "paige47"}
+{"PK": "USER#qfisher", "SK": "#METADATA#qfisher", "address": "666 Thompson Isle\nPort Gary, NV 88140", "birthdate": "1954-04-15", "email": "jpena@yahoo.com", "name": "Corey Noble", "username": "qfisher"}
+{"PK": "USER#deborah02", "SK": "#METADATA#deborah02", "address": "2837 Montgomery Trafficway\nFloresmouth, MI 70984", "birthdate": "1970-03-17", "email": "parkerpoole@hotmail.com", "name": "Michael Thompson", "username": "deborah02"}
+{"PK": "USER#vincentsusan", "SK": "#METADATA#vincentsusan", "address": "192 Baxter Radial Suite 521\nPort Ryanport, CA 10004", "birthdate": "1971-11-23", "email": "tbenson@yahoo.com", "name": "Tony Spears", "username": "vincentsusan"}
+{"PK": "USER#michael56", "SK": "#METADATA#michael56", "address": "72685 Garcia Mall Apt. 343\nWest Andrew, FL 59960", "birthdate": "1993-04-28", "email": "traceyjohnston@yahoo.com", "name": "Christine Hendricks", "username": "michael56"}
+{"PK": "USER#aweber", "SK": "#METADATA#aweber", "address": "7413 Moore Trace Suite 540\nSouth Sally, DE 54917", "birthdate": "1963-10-01", "email": "williamsjared@yahoo.com", "name": "Thomas Jennings", "username": "aweber"}
+{"PK": "USER#katherineroberts", "SK": "#METADATA#katherineroberts", "address": "801 Dixon Hills Apt. 194\nGordonfort, KY 37520", "birthdate": "1999-06-27", "email": "diana02@yahoo.com", "name": "Jessica Ingram", "username": "katherineroberts"}
+{"PK": "USER#harrisjoseph", "SK": "#METADATA#harrisjoseph", "address": "039 Russell Flats Suite 412\nEast Kennethville, MA 71343", "birthdate": "1932-09-09", "email": "heatheraustin@hotmail.com", "name": "James Brown", "username": "harrisjoseph"}
+{"PK": "USER#daykarla", "SK": "#METADATA#daykarla", "address": "PSC 6247, Box 9653\nAPO AE 62283", "birthdate": "2002-12-23", "email": "williamserik@yahoo.com", "name": "Raymond Bond", "username": "daykarla"}
+{"PK": "USER#vanessagordon", "SK": "#METADATA#vanessagordon", "address": "4143 Andrew Brook\nBrandonport, CO 76556", "birthdate": "1978-12-12", "email": "paulcarter@yahoo.com", "name": "Jonathon Diaz DDS", "username": "vanessagordon"}
+{"PK": "USER#evan71", "SK": "#METADATA#evan71", "address": "1485 Kyle Mountains Apt. 596\nShariborough, SC 69173", "birthdate": "1999-08-22", "email": "holmesdavid@gmail.com", "name": "Abigail Thompson", "username": "evan71"}
+{"PK": "USER#jenniferrodgers", "SK": "#METADATA#jenniferrodgers", "address": "43445 Lopez Mews Apt. 116\nNorth Stephanie, ID 43344", "birthdate": "1995-05-14", "email": "uchavez@yahoo.com", "name": "Tyler Smith", "username": "jenniferrodgers"}
+{"PK": "USER#richardbowman", "SK": "#METADATA#richardbowman", "address": "USCGC Harris\nFPO AA 68606", "birthdate": "1981-08-12", "email": "jason30@yahoo.com", "name": "Collin Arnold", "username": "richardbowman"}
+{"PK": "USER#flowery", "SK": "#METADATA#flowery", "address": "PSC 9282, Box 8697\nAPO AA 72618", "birthdate": "1934-11-10", "email": "erogers@yahoo.com", "name": "Andrea Bridges", "username": "flowery"}
+{"PK": "USER#lisabaker", "SK": "#METADATA#lisabaker", "address": "USNS Ferguson\nFPO AA 85815", "birthdate": "1980-04-14", "email": "churchnathaniel@hotmail.com", "name": "Michael Miller", "username": "lisabaker"}
+{"PK": "USER#nelsonmichael", "SK": "#METADATA#nelsonmichael", "address": "725 Schmidt Terrace\nLake Ashley, NY 27452", "birthdate": "1972-02-08", "email": "stephensjoseph@yahoo.com", "name": "Christopher Martinez", "username": "nelsonmichael"}
+{"PK": "USER#pierceronald", "SK": "#METADATA#pierceronald", "address": "4880 Katelyn Groves Suite 229\nBeasleyberg, ME 41195", "birthdate": "1915-11-23", "email": "jdavis@gmail.com", "name": "Carol Bates", "username": "pierceronald"}
+{"PK": "USER#hannah00", "SK": "#METADATA#hannah00", "address": "030 Robert Club\nNorth Zachary, NJ 59660", "birthdate": "1905-12-05", "email": "leslie57@hotmail.com", "name": "Amy Dawson", "username": "hannah00"}
+{"PK": "USER#jeffrey21", "SK": "#METADATA#jeffrey21", "address": "906 Brown Ports Apt. 877\nNew Alyssamouth, NC 21604", "birthdate": "1923-10-07", "email": "kristina39@hotmail.com", "name": "Elizabeth Smith", "username": "jeffrey21"}
+{"PK": "USER#fglenn", "SK": "#METADATA#fglenn", "address": "711 Cindy Inlet Suite 832\nNorth Joshua, DE 32208", "birthdate": "1993-03-06", "email": "matthewmorrison@gmail.com", "name": "Kathleen Cook", "username": "fglenn"}
+{"PK": "USER#nruiz", "SK": "#METADATA#nruiz", "address": "455 Susan Center Apt. 014\nRiostown, IA 02937", "birthdate": "1999-11-10", "email": "jodywalsh@yahoo.com", "name": "Ryan Diaz", "username": "nruiz"}
+{"PK": "USER#nancy06", "SK": "#METADATA#nancy06", "address": "91679 Allen Square Apt. 547\nSouth Karen, WI 45186", "birthdate": "1935-01-14", "email": "kyleflowers@gmail.com", "name": "Steven Padilla", "username": "nancy06"}
+{"PK": "USER#mholmes", "SK": "#METADATA#mholmes", "address": "362 Melissa Roads Apt. 666\nPort Nicole, MD 20723", "birthdate": "1911-12-04", "email": "fisherwillie@yahoo.com", "name": "Christina Williams", "username": "mholmes"}
+{"PK": "USER#woodsusan", "SK": "#METADATA#woodsusan", "address": "75615 Hatfield Row Apt. 107\nSmithfort, NC 57793", "birthdate": "1955-12-23", "email": "hjackson@yahoo.com", "name": "Andrew Rivers", "username": "woodsusan"}
+{"PK": "USER#joshuamorris", "SK": "#METADATA#joshuamorris", "address": "947 Johnson Expressway Apt. 796\nPort Michaeltown, MD 29619", "birthdate": "1972-09-09", "email": "mhicks@gmail.com", "name": "Jeffrey Villanueva", "username": "joshuamorris"}
+{"PK": "USER#carrpatrick", "SK": "#METADATA#carrpatrick", "address": "30580 Zachary Springs\nSouth Elizabethport, WV 85457", "birthdate": "1919-10-08", "email": "sarah76@hotmail.com", "name": "Mark Carroll", "username": "carrpatrick"}
+{"PK": "USER#mary57", "SK": "#METADATA#mary57", "address": "27001 Gomez Ferry Apt. 380\nNorth Joshuaport, DE 34592", "birthdate": "1918-10-17", "email": "patelnicholas@yahoo.com", "name": "Mrs. Lori Vaughn MD", "username": "mary57"}
+{"PK": "USER#cameron56", "SK": "#METADATA#cameron56", "address": "4844 Jackson Parkway\nLoristad, SC 35475", "birthdate": "1993-08-18", "email": "butlermichael@gmail.com", "name": "Timothy Evans", "username": "cameron56"}
+{"PK": "USER#ctaylor", "SK": "#METADATA#ctaylor", "address": "95609 Parrish Square Suite 587\nCindyville, ND 29038", "birthdate": "1913-06-21", "email": "jacqueline79@gmail.com", "name": "Leslie Strickland", "username": "ctaylor"}
+{"PK": "USER#kathleen52", "SK": "#METADATA#kathleen52", "address": "26839 Shelby Ranch Suite 901\nGarciafort, IL 43958", "birthdate": "1907-01-12", "email": "patrickhumphrey@yahoo.com", "name": "Terry Ruiz", "username": "kathleen52"}
+{"PK": "USER#xlucero", "SK": "#METADATA#xlucero", "address": "335 Christopher Terrace\nDuffybury, WI 27339", "birthdate": "1909-05-29", "email": "kirbymelissa@gmail.com", "name": "Ashley Hicks", "username": "xlucero"}
+{"PK": "USER#mccormickdiana", "SK": "#METADATA#mccormickdiana", "address": "USNS Page\nFPO AA 73943", "birthdate": "1976-12-26", "email": "strongaaron@hotmail.com", "name": "Kelly Mckay", "username": "mccormickdiana"}
+{"PK": "USER#rdonovan", "SK": "#METADATA#rdonovan", "address": "8432 Carpenter Station Apt. 418\nPort Kathleen, AL 53306", "birthdate": "1967-07-01", "email": "justin46@hotmail.com", "name": "Troy Carrillo", "username": "rdonovan"}
+{"PK": "USER#chadburns", "SK": "#METADATA#chadburns", "address": "8822 Daniel Trafficway\nNorth Ryan, FL 76426", "birthdate": "2012-05-05", "email": "edwardvillanueva@gmail.com", "name": "Susan Clark", "username": "chadburns"}
+{"PK": "USER#stephanie67", "SK": "#METADATA#stephanie67", "address": "21016 Karen Parkways Suite 530\nSouth Christopherburgh, ND 04215", "birthdate": "1955-01-26", "email": "sglenn@hotmail.com", "name": "Gail Edwards", "username": "stephanie67"}
+{"PK": "USER#eileen96", "SK": "#METADATA#eileen96", "address": "346 Charles Ville Apt. 371\nEast Christopherborough, WV 40901", "birthdate": "1952-04-30", "email": "wsanders@gmail.com", "name": "Tyler Wilson", "username": "eileen96"}
+{"PK": "USER#joel69", "SK": "#METADATA#joel69", "address": "470 Catherine Path Suite 084\nWilliamsberg, DE 85616", "birthdate": "1947-08-19", "email": "johnlee@hotmail.com", "name": "Stephanie Williams", "username": "joel69"}
+{"PK": "USER#qthompson", "SK": "#METADATA#qthompson", "address": "48245 Benson Manor Apt. 971\nFoleyberg, MT 73576", "birthdate": "2018-12-21", "email": "abuchanan@yahoo.com", "name": "Kevin Carroll", "username": "qthompson"}
+{"PK": "USER#ghughes", "SK": "#METADATA#ghughes", "address": "USS Jones\nFPO AE 34335", "birthdate": "1930-10-09", "email": "nicole41@gmail.com", "name": "David Beck", "username": "ghughes"}
+{"PK": "USER#lgallagher", "SK": "#METADATA#lgallagher", "address": "314 Franklin Walk\nStevensview, ME 86318", "birthdate": "2017-04-05", "email": "mark80@yahoo.com", "name": "Tiffany Watson", "username": "lgallagher"}
+{"PK": "USER#reidspencer", "SK": "#METADATA#reidspencer", "address": "4356 Johnson Glens\nNew Daniel, VA 96284", "birthdate": "1905-11-20", "email": "powersashley@hotmail.com", "name": "Jordan Smith", "username": "reidspencer"}
+{"PK": "USER#wwilliams", "SK": "#METADATA#wwilliams", "address": "52277 Brooks Coves Suite 807\nTimothystad, RI 43809", "birthdate": "1933-05-15", "email": "larry93@gmail.com", "name": "John Harris", "username": "wwilliams"}
+{"PK": "USER#bakerjerome", "SK": "#METADATA#bakerjerome", "address": "2467 David Trace Suite 972\nDanielland, AK 45239", "birthdate": "1949-03-07", "email": "davidwells@gmail.com", "name": "Dr. Todd Smith", "username": "bakerjerome"}
+{"PK": "USER#aspencer", "SK": "#METADATA#aspencer", "address": "175 Reeves Path\nLake Annebury, MN 44019", "birthdate": "1968-11-18", "email": "john45@gmail.com", "name": "Maria Lester", "username": "aspencer"}
+{"PK": "USER#camachogina", "SK": "#METADATA#camachogina", "address": "37141 White Fields\nSouth Julie, SC 09325", "birthdate": "1998-03-08", "email": "ebates@hotmail.com", "name": "Alex Harrell", "username": "camachogina"}
+{"PK": "USER#crystalanderson", "SK": "#METADATA#crystalanderson", "address": "90378 Alyssa Wall\nAmberberg, MA 41199", "birthdate": "2000-12-17", "email": "jacob33@gmail.com", "name": "Christopher Pearson", "username": "crystalanderson"}
+{"PK": "USER#cannoncrystal", "SK": "#METADATA#cannoncrystal", "address": "6727 Rachel Wells\nNorth David, NH 55195", "birthdate": "1979-05-01", "email": "elizabethschwartz@yahoo.com", "name": "Jamie Perez", "username": "cannoncrystal"}
+{"PK": "USER#christina03", "SK": "#METADATA#christina03", "address": "PSC 7595, Box 0547\nAPO AE 18317", "birthdate": "1953-11-03", "email": "stephenescobar@yahoo.com", "name": "Julian Campbell", "username": "christina03"}
+{"PK": "USER#emilyfrank", "SK": "#METADATA#emilyfrank", "address": "6790 Carolyn Fords\nBautistaberg, IL 14905", "birthdate": "1973-03-22", "email": "cameronhill@gmail.com", "name": "Anthony Stein", "username": "emilyfrank"}
+{"PK": "USER#jacquelinelloyd", "SK": "#METADATA#jacquelinelloyd", "address": "9104 Hunt Locks Suite 076\nSouth Timothy, PA 36281", "birthdate": "1950-06-30", "email": "nicolemitchell@hotmail.com", "name": "Matthew Herrera DDS", "username": "jacquelinelloyd"}
+{"PK": "USER#martinnicholas", "SK": "#METADATA#martinnicholas", "address": "773 Vega Circles Suite 303\nMorganstad, WV 10499", "birthdate": "1945-09-26", "email": "melissa86@gmail.com", "name": "Mitchell Nichols", "username": "martinnicholas"}
+{"PK": "USER#branchmichael", "SK": "#METADATA#branchmichael", "address": "1922 Catherine Court\nWest Kathleenfurt, NH 66932", "birthdate": "1913-12-13", "email": "nathanwilson@yahoo.com", "name": "Jennifer French", "username": "branchmichael"}
+{"PK": "USER#carlos80", "SK": "#METADATA#carlos80", "address": "789 Virginia Mount\nRiverafort, OH 01804", "birthdate": "1940-11-17", "email": "jennifercohen@gmail.com", "name": "Alex Gardner", "username": "carlos80"}
+{"PK": "USER#jakethompson", "SK": "#METADATA#jakethompson", "address": "266 Smith Turnpike Suite 227\nSouth Joeltown, OH 43051", "birthdate": "1941-06-29", "email": "gpeters@gmail.com", "name": "Robert Jensen", "username": "jakethompson"}
+{"PK": "USER#larrylittle", "SK": "#METADATA#larrylittle", "address": "737 Stephanie Expressway Apt. 455\nHartmantown, GA 76374", "birthdate": "1970-03-12", "email": "utaylor@yahoo.com", "name": "Dr. Jeffery Johnson MD", "username": "larrylittle"}
+{"PK": "USER#amber47", "SK": "#METADATA#amber47", "address": "84354 Jacob Park Suite 062\nPort Melissabury, DE 35397", "birthdate": "1989-05-16", "email": "alison98@gmail.com", "name": "Travis Johns", "username": "amber47"}
+{"PK": "USER#morrisonfrank", "SK": "#METADATA#morrisonfrank", "address": "93643 Harper Island Apt. 101\nHamptonburgh, GA 33431", "birthdate": "1959-02-04", "email": "patrick83@yahoo.com", "name": "Nancy Mays", "username": "morrisonfrank"}
+{"PK": "USER#amber24", "SK": "#METADATA#amber24", "address": "6559 Christy Burg\nSanchezfurt, OR 79915", "birthdate": "1922-04-09", "email": "ayalakristen@gmail.com", "name": "Amy Morales", "username": "amber24"}
+{"PK": "USER#wagnergerald", "SK": "#METADATA#wagnergerald", "address": "88321 Stacy Centers Suite 340\nWhitneyborough, DE 96006", "birthdate": "2003-01-13", "email": "davidwilson@hotmail.com", "name": "Louis Schmidt", "username": "wagnergerald"}
+{"PK": "USER#hwells", "SK": "#METADATA#hwells", "address": "8992 Jamie Vista Apt. 722\nSouth Patriciafort, ID 50240", "birthdate": "2009-05-06", "email": "csanchez@hotmail.com", "name": "Russell Williamson", "username": "hwells"}
+{"PK": "USER#fthomas", "SK": "#METADATA#fthomas", "address": "82222 Crane Branch\nNew Lukefort, ND 41160", "birthdate": "1988-01-21", "email": "hjohnson@hotmail.com", "name": "Justin Huber", "username": "fthomas"}
+{"PK": "USER#brian75", "SK": "#METADATA#brian75", "address": "86194 Jason Valley Apt. 170\nNorth Jeremy, AR 45236", "birthdate": "1922-03-08", "email": "evelez@yahoo.com", "name": "Jackson Garcia", "username": "brian75"}
+{"PK": "USER#phendrix", "SK": "#METADATA#phendrix", "address": "759 Jonathan Burg\nWest Alexandra, AK 30478", "birthdate": "1956-11-22", "email": "dylanmitchell@gmail.com", "name": "Robert Arroyo", "username": "phendrix"}
+{"PK": "USER#johnsonrobert", "SK": "#METADATA#johnsonrobert", "address": "851 Garcia Trace Apt. 600\nSouth Sarah, AZ 49773", "birthdate": "2011-04-26", "email": "troyfuller@hotmail.com", "name": "Sarah Watts", "username": "johnsonrobert"}
+{"PK": "USER#yatesdebra", "SK": "#METADATA#yatesdebra", "address": "406 Bonnie Courts\nRodriguezstad, UT 75135", "birthdate": "1944-08-29", "email": "kmcintosh@gmail.com", "name": "Sarah Johnson", "username": "yatesdebra"}
+{"PK": "USER#scott72", "SK": "#METADATA#scott72", "address": "PSC 6043, Box 4759\nAPO AA 13229", "birthdate": "1987-06-23", "email": "bruce94@hotmail.com", "name": "Richard Vasquez", "username": "scott72"}
+{"PK": "USER#simmonsmeredith", "SK": "#METADATA#simmonsmeredith", "address": "41433 Eric Grove\nGutierrezhaven, SC 87261", "birthdate": "1925-07-30", "email": "jasonstewart@gmail.com", "name": "Toni Rivas MD", "username": "simmonsmeredith"}
+{"PK": "USER#hayeserin", "SK": "#METADATA#hayeserin", "address": "5050 Ryan Ridges Suite 904\nNorth Meghan, VT 60120", "birthdate": "2013-11-09", "email": "derrickthornton@yahoo.com", "name": "Nicole Carr", "username": "hayeserin"}
+{"PK": "USER#joshuameza", "SK": "#METADATA#joshuameza", "address": "Unit 4917 Box 3182\nDPO AA 60915", "birthdate": "2017-04-09", "email": "lori62@gmail.com", "name": "Jesus Ayers", "username": "joshuameza"}
+{"PK": "USER#jenniferjohnson", "SK": "#METADATA#jenniferjohnson", "address": "12867 Yang Springs\nKelseyville, NY 59794", "birthdate": "1947-12-14", "email": "roypaul@yahoo.com", "name": "Jasmine Collins", "username": "jenniferjohnson"}
+{"PK": "USER#carl31", "SK": "#METADATA#carl31", "address": "976 Johnson Rapids\nLake Christopherstad, KY 32271", "birthdate": "1905-08-24", "email": "edwardsmith@yahoo.com", "name": "Amy Young", "username": "carl31"}
+{"PK": "USER#darren23", "SK": "#METADATA#darren23", "address": "593 Melissa Inlet Suite 381\nEast Jeffery, CO 95996", "birthdate": "1928-12-13", "email": "brittanygoodman@gmail.com", "name": "Mary Gonzalez", "username": "darren23"}
+{"PK": "USER#deanmcclure", "SK": "#METADATA#deanmcclure", "address": "887 Monica Junctions\nWest Cynthiastad, NV 56423", "birthdate": "2017-08-28", "email": "mpreston@hotmail.com", "name": "Alison Schwartz", "username": "deanmcclure"}
+{"PK": "USER#reesebruce", "SK": "#METADATA#reesebruce", "address": "Unit 9016 Box 8936\nDPO AP 45296", "birthdate": "1986-11-01", "email": "yterry@hotmail.com", "name": "Renee Harris", "username": "reesebruce"}
+{"PK": "USER#garciajohn", "SK": "#METADATA#garciajohn", "address": "56784 Julie Spring Suite 955\nNorth Amberport, NE 33157", "birthdate": "1996-02-14", "email": "hernandezlawrence@yahoo.com", "name": "Isaac Skinner", "username": "garciajohn"}
+{"PK": "USER#gsmith", "SK": "#METADATA#gsmith", "address": "35484 Stacey Mews Apt. 861\nSheaberg, AL 97127", "birthdate": "1921-01-02", "email": "hollywade@yahoo.com", "name": "Tracy Brown", "username": "gsmith"}
+{"PK": "USER#stephensmarissa", "SK": "#METADATA#stephensmarissa", "address": "57327 Bryant Place\nAndreaport, DC 38098", "birthdate": "2014-01-26", "email": "holly95@gmail.com", "name": "Willie Potter", "username": "stephensmarissa"}
+{"PK": "USER#jasonpetty", "SK": "#METADATA#jasonpetty", "address": "USNV Dennis\nFPO AE 30805", "birthdate": "1986-10-03", "email": "fzhang@hotmail.com", "name": "Jennifer Barr", "username": "jasonpetty"}
+{"PK": "USER#danielgarcia", "SK": "#METADATA#danielgarcia", "address": "5325 Rivera Wells\nLopeztown, WV 94462", "birthdate": "1950-02-10", "email": "christopherlee@yahoo.com", "name": "David Haas", "username": "danielgarcia"}
+{"PK": "USER#meghanhernandez", "SK": "#METADATA#meghanhernandez", "address": "975 Lisa Road Apt. 425\nRonaldfurt, MI 43995", "birthdate": "2000-12-06", "email": "daniellamb@gmail.com", "name": "Elizabeth Castillo", "username": "meghanhernandez"}
+{"PK": "USER#scortez", "SK": "#METADATA#scortez", "address": "0452 Sandra Via\nLake James, NH 47864", "birthdate": "2001-03-13", "email": "michael46@yahoo.com", "name": "Matthew Buck", "username": "scortez"}
+{"PK": "USER#gabriellerivera", "SK": "#METADATA#gabriellerivera", "address": "51070 Jones Lakes Apt. 291\nNorth Sarashire, DC 72122", "birthdate": "1948-01-06", "email": "kinghenry@gmail.com", "name": "Steven Miller", "username": "gabriellerivera"}
+{"PK": "USER#shannon11", "SK": "#METADATA#shannon11", "address": "USCGC Flores\nFPO AP 75041", "birthdate": "1928-10-18", "email": "hunterjones@yahoo.com", "name": "Taylor Morrow", "username": "shannon11"}
+{"PK": "USER#thomasmichael", "SK": "#METADATA#thomasmichael", "address": "949 Michael Mission\nEast Yolandahaven, PA 75408", "birthdate": "1910-03-24", "email": "lonnielawrence@yahoo.com", "name": "Carlos Henderson", "username": "thomasmichael"}
+{"PK": "USER#smithshannon", "SK": "#METADATA#smithshannon", "address": "539 Stephen Valleys Apt. 213\nEast Andrewshire, OH 07085", "birthdate": "2000-08-24", "email": "pball@yahoo.com", "name": "Ronald Morgan", "username": "smithshannon"}
+{"PK": "USER#vlopez", "SK": "#METADATA#vlopez", "address": "3036 Powell Ports Suite 131\nNorth Albert, MD 07237", "birthdate": "1960-06-16", "email": "garciakenneth@gmail.com", "name": "William Hernandez", "username": "vlopez"}
+{"PK": "USER#pboyd", "SK": "#METADATA#pboyd", "address": "8745 David Dam Suite 286\nChristopherborough, MN 61530", "birthdate": "1957-05-25", "email": "theresacampbell@gmail.com", "name": "Jenny Turner", "username": "pboyd"}
+{"PK": "USER#elizabethgreen", "SK": "#METADATA#elizabethgreen", "address": "65832 Berg Garden Apt. 720\nNorth Elizabethton, AK 61035", "birthdate": "1974-11-03", "email": "xdavis@hotmail.com", "name": "Ryan Jones", "username": "elizabethgreen"}
+{"PK": "USER#petersonjohn", "SK": "#METADATA#petersonjohn", "address": "04283 Jones Lane\nWhiteview, OR 98057", "birthdate": "1957-06-23", "email": "aatkins@gmail.com", "name": "Paul Watson", "username": "petersonjohn"}
+{"PK": "USER#jasonlozano", "SK": "#METADATA#jasonlozano", "address": "0233 Timothy Mall\nLake Erinborough, DE 97254", "birthdate": "2004-02-11", "email": "daniel78@hotmail.com", "name": "Mark Cummings", "username": "jasonlozano"}
+{"PK": "USER#fcummings", "SK": "#METADATA#fcummings", "address": "991 Schroeder Burg Suite 699\nEast Joshua, VA 34031", "birthdate": "1961-08-22", "email": "daviscynthia@yahoo.com", "name": "Christopher Shah", "username": "fcummings"}
+{"PK": "USER#isabellalynch", "SK": "#METADATA#isabellalynch", "address": "106 Kathy Mission Apt. 565\nJessicabury, NC 45509", "birthdate": "1982-06-23", "email": "linda22@hotmail.com", "name": "Nicole Conley", "username": "isabellalynch"}
+{"PK": "USER#esmith", "SK": "#METADATA#esmith", "address": "593 Martinez Courts\nTonyaside, ME 81426", "birthdate": "2006-07-15", "email": "bonnie37@yahoo.com", "name": "Wanda Smith", "username": "esmith"}
+{"PK": "USER#hendersonbridget", "SK": "#METADATA#hendersonbridget", "address": "5287 Marsh Expressway\nWest Devinville, NV 42049", "birthdate": "1961-12-07", "email": "cartermichael@yahoo.com", "name": "Holly Morrison", "username": "hendersonbridget"}
+{"PK": "USER#josephmiles", "SK": "#METADATA#josephmiles", "address": "782 Frye Parkways Suite 991\nHullville, OK 20559", "birthdate": "1972-03-13", "email": "powellkristen@hotmail.com", "name": "Douglas Brown", "username": "josephmiles"}
+{"PK": "USER#farellano", "SK": "#METADATA#farellano", "address": "3958 Edward Summit Suite 448\nNorth William, NH 66494", "birthdate": "1911-03-25", "email": "ericabranch@hotmail.com", "name": "Victoria Barr", "username": "farellano"}
+{"PK": "USER#heatherlee", "SK": "#METADATA#heatherlee", "address": "4089 Barr Points Suite 861\nWest Andrewstad, DE 79815", "birthdate": "1964-12-01", "email": "julianthompson@hotmail.com", "name": "Tabitha Smith", "username": "heatherlee"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "#METADATA#0ab37cf1-fc60-4d93-b72b-89335f759581", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581", "map": "Green Grasslands", "create_time": "2019-04-16T00:41:18", "people": 34, "open_timestamp": "2019-04-16T00:41:18", "creator": "jackparks"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "#METADATA#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "map": "Dirty Desert", "create_time": "2019-04-13T14:25:57", "people": 50, "start_time": "2019-04-13T14:36:25", "creator": "gstanley"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "#METADATA#292c8712-c9df-4721-a9a2-cae4ac607ed6", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6", "map": "Dirty Desert", "create_time": "2019-04-14T08:04:23", "people": 50, "start_time": "2019-04-14T08:15:56", "creator": "bentonsharon"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "#METADATA#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "map": "Green Grasslands", "create_time": "2019-04-14T03:32:57", "people": 50, "start_time": "2019-04-14T03:46:12", "end_time": "2019-04-14T03:35:02", "creator": "phendrix", "gold": "pboyd", "silver": "carrpatrick", "bronze": "reidspencer"}
+{"PK": "GAME#14c7f97e-8354-4ddf-985f-074970818215", "SK": "#METADATA#14c7f97e-8354-4ddf-985f-074970818215", "game_id": "14c7f97e-8354-4ddf-985f-074970818215", "map": "Green Grasslands", "create_time": "2019-04-14T12:48:59", "people": 1, "open_timestamp": "2019-04-14T12:48:59", "creator": "jennifer32"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "#METADATA#3a816c56-53e9-4d42-a76d-fa4af24b9842", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842", "map": "Dirty Desert", "create_time": "2019-04-14T05:36:33", "people": 50, "start_time": "2019-04-14T05:45:33", "creator": "hwolf"}
+{"PK": "GAME#d06af94a-2363-441d-a69b-49e3f85e748a", "SK": "#METADATA#d06af94a-2363-441d-a69b-49e3f85e748a", "game_id": "d06af94a-2363-441d-a69b-49e3f85e748a", "map": "Dirty Desert", "create_time": "2019-04-14T06:10:42", "people": 1, "open_timestamp": "2019-04-14T06:10:42", "creator": "evan71"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "#METADATA#873aaf13-0847-4661-ba26-21e0c66ebe64", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64", "map": "Dirty Desert", "create_time": "2019-04-14T12:18:51", "people": 21, "open_timestamp": "2019-04-14T12:18:51", "creator": "nancy26"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "#METADATA#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174", "map": "Juicy Jungle", "create_time": "2019-04-14T17:25:48", "people": 17, "open_timestamp": "2019-04-14T17:25:48", "creator": "angela85"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "#METADATA#fe89e561-8a93-4e08-84d8-efa88bef383d", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d", "map": "Dirty Desert", "create_time": "2019-04-15T08:46:27", "people": 34, "open_timestamp": "2019-04-15T08:46:27", "creator": "dchavez"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "#METADATA#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3", "map": "Green Grasslands", "create_time": "2019-04-15T12:55:44", "people": 46, "open_timestamp": "2019-04-15T12:55:44", "creator": "pboyd"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "#METADATA#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "map": "Urban Underground", "create_time": "2019-04-16T10:12:54", "people": 49, "open_timestamp": "2019-04-16T10:12:54", "creator": "gstanley"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "#METADATA#5e24f988-0682-418b-947a-d5feec6c483d", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d", "map": "Open Ocean", "create_time": "2019-04-16T05:40:26", "people": 50, "start_time": "2019-04-16T05:48:20", "creator": "tiffany19"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "#METADATA#f25030b7-5db0-44d5-ae76-4d310ef24e08", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08", "map": "Dirty Desert", "create_time": "2019-04-15T11:01:21", "people": 50, "start_time": "2019-04-15T11:15:23", "end_time": "2019-04-15T11:11:47", "creator": "jasonbarton", "gold": "kimberly02", "silver": "robinsonbenjamin", "bronze": "lindsaypayne"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "#METADATA#3d4285f0-e52b-401a-a59b-112b38c4a26b", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b", "map": "Green Grasslands", "create_time": "2019-04-15T05:34:34", "people": 17, "open_timestamp": "2019-04-15T05:34:34", "creator": "victoriapatrick"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#hshort", "username": "hshort", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#kellercole", "username": "kellercole", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#kellydavid", "username": "kellydavid", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#smithshannon", "username": "smithshannon", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#joshuaferguson", "username": "joshuaferguson", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#richardandrews", "username": "richardandrews", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#amber24", "username": "amber24", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#jackparks", "username": "jackparks", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#maryharris", "username": "maryharris", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#reesebruce", "username": "reesebruce", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#esmith", "username": "esmith", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#matthewday", "username": "matthewday", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#mcampbell", "username": "mcampbell", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#hwells", "username": "hwells", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#wwilliams", "username": "wwilliams", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#jennifer32", "username": "jennifer32", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#umartin", "username": "umartin", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#nruiz", "username": "nruiz", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#icole", "username": "icole", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#roselaurie", "username": "roselaurie", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#camachogina", "username": "camachogina", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#hgeorge", "username": "hgeorge", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#caseychristian", "username": "caseychristian", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#tommyleon", "username": "tommyleon", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#millerashlee", "username": "millerashlee", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#megandorsey", "username": "megandorsey", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#gsmith", "username": "gsmith", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#hendersonbridget", "username": "hendersonbridget", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#richardbowman", "username": "richardbowman", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#pgray", "username": "pgray", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#scott45", "username": "scott45", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#yatesdebra", "username": "yatesdebra", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#wcamacho", "username": "wcamacho", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#0ab37cf1-fc60-4d93-b72b-89335f759581", "SK": "USER#wardmichelle", "username": "wardmichelle", "game_id": "0ab37cf1-fc60-4d93-b72b-89335f759581"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#roselaurie", "username": "roselaurie", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#andersonbrittney", "username": "andersonbrittney", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#pierceronald", "username": "pierceronald", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#kevinsmith", "username": "kevinsmith", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#hwells", "username": "hwells", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#michael37", "username": "michael37", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#thomasmichael", "username": "thomasmichael", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#louis83", "username": "louis83", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#zacharyreed", "username": "zacharyreed", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#gstanley", "username": "gstanley", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#kellydavid", "username": "kellydavid", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#millerashlee", "username": "millerashlee", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#lisabaker", "username": "lisabaker", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#gutierrezjohn", "username": "gutierrezjohn", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#ywyatt", "username": "ywyatt", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#madelineharrison", "username": "madelineharrison", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#cjohnson", "username": "cjohnson", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#caseychristian", "username": "caseychristian", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#connie13", "username": "connie13", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#qbartlett", "username": "qbartlett", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#christina03", "username": "christina03", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#garciajohn", "username": "garciajohn", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#sandramorrison", "username": "sandramorrison", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#darren23", "username": "darren23", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#kaufmanrobin", "username": "kaufmanrobin", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#martinnicholas", "username": "martinnicholas", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#derrickevans", "username": "derrickevans", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#petersonjohn", "username": "petersonjohn", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#ohayes", "username": "ohayes", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#gabriellerivera", "username": "gabriellerivera", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#jeremyjohnson", "username": "jeremyjohnson", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#jeremy02", "username": "jeremy02", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#ricky31", "username": "ricky31", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#aweber", "username": "aweber", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#jacquelinelloyd", "username": "jacquelinelloyd", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#bwhitaker", "username": "bwhitaker", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#matthewevans", "username": "matthewevans", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#emma83", "username": "emma83", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#smithshannon", "username": "smithshannon", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#flowery", "username": "flowery", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#stevendavis", "username": "stevendavis", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#scortez", "username": "scortez", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#igaines", "username": "igaines", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#hayeserin", "username": "hayeserin", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#angela85", "username": "angela85", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#bhernandez", "username": "bhernandez", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#johnsonscott", "username": "johnsonscott", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#austincervantes", "username": "austincervantes", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#carrpatrick", "username": "carrpatrick", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd", "SK": "USER#fosterandrew", "username": "fosterandrew", "game_id": "c9c3917e-30f3-4ba4-82c4-2e9a0e4d1cfd"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#scott19", "username": "scott19", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#wardmichelle", "username": "wardmichelle", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#victoriapatrick", "username": "victoriapatrick", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#johnsonwendy", "username": "johnsonwendy", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#mckenziemoreno", "username": "mckenziemoreno", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#gabriellerivera", "username": "gabriellerivera", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#katherineroberts", "username": "katherineroberts", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#stephanie67", "username": "stephanie67", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#joshuaferguson", "username": "joshuaferguson", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#sandovalpamela", "username": "sandovalpamela", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#paige47", "username": "paige47", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#mbrown", "username": "mbrown", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#tony22", "username": "tony22", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#mary60", "username": "mary60", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#robertwood", "username": "robertwood", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#thomas79", "username": "thomas79", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#bentonsharon", "username": "bentonsharon", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#frederickbradford", "username": "frederickbradford", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#joshuameza", "username": "joshuameza", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#schwartzannette", "username": "schwartzannette", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#eric53", "username": "eric53", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#branchmichael", "username": "branchmichael", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#johnwilliams", "username": "johnwilliams", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#matthewday", "username": "matthewday", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#ralph89", "username": "ralph89", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#cameron56", "username": "cameron56", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#anastrong", "username": "anastrong", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#eileen96", "username": "eileen96", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#xlucero", "username": "xlucero", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#slawson", "username": "slawson", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#wcamacho", "username": "wcamacho", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#hannah93", "username": "hannah93", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#bakerjerome", "username": "bakerjerome", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#sdiaz", "username": "sdiaz", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#louis83", "username": "louis83", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#tommyleon", "username": "tommyleon", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#ywyatt", "username": "ywyatt", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#brandon30", "username": "brandon30", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#jasonlozano", "username": "jasonlozano", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#emilyfrank", "username": "emilyfrank", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#alexander03", "username": "alexander03", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#usimpson", "username": "usimpson", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#philipsingleton", "username": "philipsingleton", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#angelaoliver", "username": "angelaoliver", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#cannoncrystal", "username": "cannoncrystal", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#ugonzales", "username": "ugonzales", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#harrisjoseph", "username": "harrisjoseph", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#carlos80", "username": "carlos80", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#baldwinangela", "username": "baldwinangela", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#292c8712-c9df-4721-a9a2-cae4ac607ed6", "SK": "USER#usmith", "username": "usmith", "game_id": "292c8712-c9df-4721-a9a2-cae4ac607ed6"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#cameron56", "username": "cameron56", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#sylviamoreno", "username": "sylviamoreno", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#phillipsjessica", "username": "phillipsjessica", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#staylor", "username": "staylor", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#amber47", "username": "amber47", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#qcruz", "username": "qcruz", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#stephanie67", "username": "stephanie67", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#slawson", "username": "slawson", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#roselaurie", "username": "roselaurie", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#aguilartracey", "username": "aguilartracey", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#powelltamara", "username": "powelltamara", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#kellydavid", "username": "kellydavid", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#townsendjohn", "username": "townsendjohn", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#farellano", "username": "farellano", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#pboyd", "username": "pboyd", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "place": "gold"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#caseychristian", "username": "caseychristian", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#tracyhodge", "username": "tracyhodge", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#phendrix", "username": "phendrix", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#fcummings", "username": "fcummings", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#carrpatrick", "username": "carrpatrick", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "place": "silver"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#smithshannon", "username": "smithshannon", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#evan71", "username": "evan71", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#hendersonbridget", "username": "hendersonbridget", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#reidspencer", "username": "reidspencer", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "place": "bronze"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#maryharris", "username": "maryharris", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#anastrong", "username": "anastrong", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#jacquelinelloyd", "username": "jacquelinelloyd", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#iherrera", "username": "iherrera", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#louis83", "username": "louis83", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#mary60", "username": "mary60", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#usmith", "username": "usmith", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#deanmcclure", "username": "deanmcclure", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#johnsonscott", "username": "johnsonscott", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#umartin", "username": "umartin", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#gsmith", "username": "gsmith", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#reesebruce", "username": "reesebruce", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#connie13", "username": "connie13", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#robinsonmonica", "username": "robinsonmonica", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#harrisjoseph", "username": "harrisjoseph", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#kristine54", "username": "kristine54", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#flowery", "username": "flowery", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#andersonbrittney", "username": "andersonbrittney", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#figueroaaaron", "username": "figueroaaaron", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#larrylittle", "username": "larrylittle", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#johnwilliams", "username": "johnwilliams", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#jasonbarton", "username": "jasonbarton", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#vincentsusan", "username": "vincentsusan", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#meghanhernandez", "username": "meghanhernandez", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#mcampbell", "username": "mcampbell", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#25cec5bf-e498-483e-9a00-a5f93b9ea7c7", "SK": "USER#icole", "username": "icole", "game_id": "25cec5bf-e498-483e-9a00-a5f93b9ea7c7"}
+{"PK": "GAME#14c7f97e-8354-4ddf-985f-074970818215", "SK": "USER#jennifer32", "username": "jennifer32", "game_id": "14c7f97e-8354-4ddf-985f-074970818215"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#parkeranthony", "username": "parkeranthony", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#eric53", "username": "eric53", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#joel69", "username": "joel69", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#megandorsey", "username": "megandorsey", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#isabellalynch", "username": "isabellalynch", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#elloyd", "username": "elloyd", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#aweber", "username": "aweber", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#clarkshaun", "username": "clarkshaun", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#mayrebecca", "username": "mayrebecca", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#kcabrera", "username": "kcabrera", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#gregoryreynolds", "username": "gregoryreynolds", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#darren23", "username": "darren23", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#nancy26", "username": "nancy26", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#robert98", "username": "robert98", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#nelsonmichael", "username": "nelsonmichael", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#reidspencer", "username": "reidspencer", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#daykarla", "username": "daykarla", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#michael56", "username": "michael56", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#gonzalezalbert", "username": "gonzalezalbert", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#jacquelinelloyd", "username": "jacquelinelloyd", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#kristin06", "username": "kristin06", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#alvaradonathan", "username": "alvaradonathan", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#sylviamoreno", "username": "sylviamoreno", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#scott19", "username": "scott19", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#prodriguez", "username": "prodriguez", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#icole", "username": "icole", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#ywyatt", "username": "ywyatt", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#brenda89", "username": "brenda89", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#millerashlee", "username": "millerashlee", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#hwolf", "username": "hwolf", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#qfisher", "username": "qfisher", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#gutierrezjohn", "username": "gutierrezjohn", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#nicholas28", "username": "nicholas28", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#douglas54", "username": "douglas54", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#igaines", "username": "igaines", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#colinbutler", "username": "colinbutler", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#mcampbell", "username": "mcampbell", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#heather05", "username": "heather05", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#bakerjerome", "username": "bakerjerome", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#matthewevans", "username": "matthewevans", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#amber47", "username": "amber47", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#slawson", "username": "slawson", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#derrick36", "username": "derrick36", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#carl31", "username": "carl31", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#angelaoliver", "username": "angelaoliver", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#jasonpetty", "username": "jasonpetty", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#alexander03", "username": "alexander03", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#vanessagordon", "username": "vanessagordon", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#townsendjohn", "username": "townsendjohn", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#3a816c56-53e9-4d42-a76d-fa4af24b9842", "SK": "USER#sandramorrison", "username": "sandramorrison", "game_id": "3a816c56-53e9-4d42-a76d-fa4af24b9842"}
+{"PK": "GAME#d06af94a-2363-441d-a69b-49e3f85e748a", "SK": "USER#evan71", "username": "evan71", "game_id": "d06af94a-2363-441d-a69b-49e3f85e748a"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#julie80", "username": "julie80", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#ralph89", "username": "ralph89", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#petersonjohn", "username": "petersonjohn", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#cjohnson", "username": "cjohnson", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#nancy26", "username": "nancy26", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#mholmes", "username": "mholmes", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#mccormickdiana", "username": "mccormickdiana", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#gstanley", "username": "gstanley", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#kevinsmith", "username": "kevinsmith", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#ckelley", "username": "ckelley", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#umartin", "username": "umartin", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#sandramorrison", "username": "sandramorrison", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#wwilliams", "username": "wwilliams", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#dianaclay", "username": "dianaclay", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#roberthill", "username": "roberthill", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#mstone", "username": "mstone", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#smithshannon", "username": "smithshannon", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#mclaughlinjeff", "username": "mclaughlinjeff", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#angela85", "username": "angela85", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#isabellalynch", "username": "isabellalynch", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#873aaf13-0847-4661-ba26-21e0c66ebe64", "SK": "USER#colinbutler", "username": "colinbutler", "game_id": "873aaf13-0847-4661-ba26-21e0c66ebe64"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#branchmichael", "username": "branchmichael", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#jenniferrodgers", "username": "jenniferrodgers", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#stephanie67", "username": "stephanie67", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#rachel67", "username": "rachel67", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#slawson", "username": "slawson", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#hbarron", "username": "hbarron", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#katherineroberts", "username": "katherineroberts", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#scortez", "username": "scortez", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#tony22", "username": "tony22", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#kellymiller", "username": "kellymiller", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#parkeranthony", "username": "parkeranthony", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#angela85", "username": "angela85", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#robert51", "username": "robert51", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#jonesbilly", "username": "jonesbilly", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#zacharyreed", "username": "zacharyreed", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#jenniferjohnson", "username": "jenniferjohnson", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#248dd9ef-6b17-42f0-9567-2cbd3dd63174", "SK": "USER#jerry26", "username": "jerry26", "game_id": "248dd9ef-6b17-42f0-9567-2cbd3dd63174"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#staylor", "username": "staylor", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#alvaradonathan", "username": "alvaradonathan", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#frederickbradford", "username": "frederickbradford", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#maryjoseph", "username": "maryjoseph", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#mclaughlinjeff", "username": "mclaughlinjeff", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#wgregory", "username": "wgregory", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#stevendavis", "username": "stevendavis", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#cjohnson", "username": "cjohnson", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#wagnergerald", "username": "wagnergerald", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#parkeranthony", "username": "parkeranthony", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#guzmanfrank", "username": "guzmanfrank", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#dchavez", "username": "dchavez", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#connie13", "username": "connie13", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#pruiz", "username": "pruiz", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#joshuamorris", "username": "joshuamorris", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#gregoryreynolds", "username": "gregoryreynolds", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#tiffany19", "username": "tiffany19", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#rosesandra", "username": "rosesandra", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#jennifer97", "username": "jennifer97", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#paige47", "username": "paige47", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#wknight", "username": "wknight", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#caseychristian", "username": "caseychristian", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#jenniferrodgers", "username": "jenniferrodgers", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#emma83", "username": "emma83", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#evan71", "username": "evan71", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#nancy06", "username": "nancy06", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#smithshannon", "username": "smithshannon", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#dianaclay", "username": "dianaclay", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#shannon11", "username": "shannon11", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#gglover", "username": "gglover", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#richardandrews", "username": "richardandrews", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#hwolf", "username": "hwolf", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#ohayes", "username": "ohayes", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#fe89e561-8a93-4e08-84d8-efa88bef383d", "SK": "USER#jasonbarton", "username": "jasonbarton", "game_id": "fe89e561-8a93-4e08-84d8-efa88bef383d"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#josephmiles", "username": "josephmiles", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#brenda89", "username": "brenda89", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#wknight", "username": "wknight", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#dianaclay", "username": "dianaclay", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#kristin06", "username": "kristin06", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#brandon30", "username": "brandon30", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#kellercole", "username": "kellercole", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#nicholas28", "username": "nicholas28", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#sean79", "username": "sean79", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#usmith", "username": "usmith", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#petersonjohn", "username": "petersonjohn", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#kimberly02", "username": "kimberly02", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#jenniferlarsen", "username": "jenniferlarsen", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#johnwilliams", "username": "johnwilliams", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#sylviamoreno", "username": "sylviamoreno", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#staylor", "username": "staylor", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#wcamacho", "username": "wcamacho", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#jonesbilly", "username": "jonesbilly", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#kingmelissa", "username": "kingmelissa", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#heather05", "username": "heather05", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#anthony67", "username": "anthony67", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#jenniferjohnson", "username": "jenniferjohnson", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#bhernandez", "username": "bhernandez", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#usimpson", "username": "usimpson", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#howard47", "username": "howard47", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#connie13", "username": "connie13", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#frederickbradford", "username": "frederickbradford", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#cpowers", "username": "cpowers", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#umartin", "username": "umartin", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#shannon11", "username": "shannon11", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#stevendavis", "username": "stevendavis", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#kellymiller", "username": "kellymiller", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#johnsonrobert", "username": "johnsonrobert", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#richard21", "username": "richard21", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#pboyd", "username": "pboyd", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#sdavis", "username": "sdavis", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#ohayes", "username": "ohayes", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#fsutton", "username": "fsutton", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#daykarla", "username": "daykarla", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#rachel67", "username": "rachel67", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#matthewevans", "username": "matthewevans", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#rosesandra", "username": "rosesandra", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#grayterri", "username": "grayterri", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#amber47", "username": "amber47", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#tommyleon", "username": "tommyleon", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#683680f0-02b0-4e5e-a36a-be4e00fc93f3", "SK": "USER#rdonovan", "username": "rdonovan", "game_id": "683680f0-02b0-4e5e-a36a-be4e00fc93f3"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#rdonovan", "username": "rdonovan", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#robert51", "username": "robert51", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#cameron56", "username": "cameron56", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#kimberly02", "username": "kimberly02", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#dchavez", "username": "dchavez", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#toddmaynard", "username": "toddmaynard", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#clarkshaun", "username": "clarkshaun", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#sdavis", "username": "sdavis", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#joshuamorris", "username": "joshuamorris", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#amber24", "username": "amber24", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#umartin", "username": "umartin", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#stephanie67", "username": "stephanie67", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#hannah93", "username": "hannah93", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#epayne", "username": "epayne", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#jonesbilly", "username": "jonesbilly", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#jmiller", "username": "jmiller", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#carrpatrick", "username": "carrpatrick", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#colinbutler", "username": "colinbutler", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#kevinsmith", "username": "kevinsmith", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#qcruz", "username": "qcruz", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#garciajohn", "username": "garciajohn", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#fcummings", "username": "fcummings", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#millerashlee", "username": "millerashlee", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#lindsaypayne", "username": "lindsaypayne", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#gregory96", "username": "gregory96", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#floresmonica", "username": "floresmonica", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#kellymiller", "username": "kellymiller", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#zacharyreed", "username": "zacharyreed", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#sylviamoreno", "username": "sylviamoreno", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#jennifer97", "username": "jennifer97", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#sototheresa", "username": "sototheresa", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#meghanhernandez", "username": "meghanhernandez", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#deanmcclure", "username": "deanmcclure", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#tommyleon", "username": "tommyleon", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#martinnicholas", "username": "martinnicholas", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#joshuaacosta", "username": "joshuaacosta", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#jenniferjohnson", "username": "jenniferjohnson", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#simmonsmeredith", "username": "simmonsmeredith", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#frederickbradford", "username": "frederickbradford", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#ugonzales", "username": "ugonzales", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#wknight", "username": "wknight", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#hannah00", "username": "hannah00", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#kristine54", "username": "kristine54", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#jasonpetty", "username": "jasonpetty", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#brandon30", "username": "brandon30", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#isabellalynch", "username": "isabellalynch", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#guzmanfrank", "username": "guzmanfrank", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#kristin06", "username": "kristin06", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#c6f38a6a-d1c5-4bdf-8468-24692ccc4646", "SK": "USER#gstanley", "username": "gstanley", "game_id": "c6f38a6a-d1c5-4bdf-8468-24692ccc4646"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#alvaradonathan", "username": "alvaradonathan", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#ejones", "username": "ejones", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#brittany45", "username": "brittany45", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#carl23", "username": "carl23", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#scott19", "username": "scott19", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#eileen96", "username": "eileen96", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#kathleen52", "username": "kathleen52", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#autumnhowell", "username": "autumnhowell", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#michael37", "username": "michael37", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#morgankeith", "username": "morgankeith", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#hwolf", "username": "hwolf", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#wcamacho", "username": "wcamacho", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#robertwood", "username": "robertwood", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#derrickevans", "username": "derrickevans", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#epayne", "username": "epayne", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#lgallagher", "username": "lgallagher", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#jackson64", "username": "jackson64", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#tiffany19", "username": "tiffany19", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#ywyatt", "username": "ywyatt", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#angela85", "username": "angela85", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#connie13", "username": "connie13", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#amber24", "username": "amber24", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#cameron56", "username": "cameron56", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#deborah02", "username": "deborah02", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#shannon11", "username": "shannon11", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#mccormickdiana", "username": "mccormickdiana", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#melissasanchez", "username": "melissasanchez", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#eric53", "username": "eric53", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#richardandrews", "username": "richardandrews", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#phillipsjessica", "username": "phillipsjessica", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#joshuaferguson", "username": "joshuaferguson", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#haleykrystal", "username": "haleykrystal", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#carlos80", "username": "carlos80", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#tony22", "username": "tony22", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#sototheresa", "username": "sototheresa", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#kellymiller", "username": "kellymiller", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#mstone", "username": "mstone", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#johnwilliams", "username": "johnwilliams", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#katherineroberts", "username": "katherineroberts", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#aweber", "username": "aweber", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#jeremy02", "username": "jeremy02", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#anastrong", "username": "anastrong", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#joshuameza", "username": "joshuameza", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#aguilartracey", "username": "aguilartracey", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#gregory96", "username": "gregory96", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#zacharyreed", "username": "zacharyreed", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#brandon30", "username": "brandon30", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#carl31", "username": "carl31", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#wgregory", "username": "wgregory", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#5e24f988-0682-418b-947a-d5feec6c483d", "SK": "USER#prodriguez", "username": "prodriguez", "game_id": "5e24f988-0682-418b-947a-d5feec6c483d"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#wardmichelle", "username": "wardmichelle", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#gstanley", "username": "gstanley", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#kellymiller", "username": "kellymiller", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#kcabrera", "username": "kcabrera", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#robinsonbenjamin", "username": "robinsonbenjamin", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08", "place": "silver"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#greenbrandon", "username": "greenbrandon", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#sototheresa", "username": "sototheresa", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#smithshannon", "username": "smithshannon", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#fsutton", "username": "fsutton", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#heatherlee", "username": "heatherlee", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#robert51", "username": "robert51", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#darren23", "username": "darren23", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#pgray", "username": "pgray", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#austincervantes", "username": "austincervantes", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#haleykrystal", "username": "haleykrystal", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#joshuaacosta", "username": "joshuaacosta", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#brandon30", "username": "brandon30", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#scott45", "username": "scott45", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#kimberly02", "username": "kimberly02", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08", "place": "gold"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#brian75", "username": "brian75", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#angela85", "username": "angela85", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#phillipsjessica", "username": "phillipsjessica", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#simmonsmeredith", "username": "simmonsmeredith", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#lucasdavis", "username": "lucasdavis", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#atkinscarolyn", "username": "atkinscarolyn", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#rdonovan", "username": "rdonovan", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#alexander03", "username": "alexander03", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#mary57", "username": "mary57", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#jasonbarton", "username": "jasonbarton", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#ywyatt", "username": "ywyatt", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#jennifer32", "username": "jennifer32", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#carl31", "username": "carl31", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#bentonsharon", "username": "bentonsharon", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#usmith", "username": "usmith", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#camachogina", "username": "camachogina", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#julie80", "username": "julie80", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#josephmiles", "username": "josephmiles", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#amymorgan", "username": "amymorgan", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#toddmaynard", "username": "toddmaynard", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#cameron56", "username": "cameron56", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#jonesbilly", "username": "jonesbilly", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#gabriellerivera", "username": "gabriellerivera", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#ugonzales", "username": "ugonzales", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#evan71", "username": "evan71", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#lindsaypayne", "username": "lindsaypayne", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08", "place": "bronze"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#johnsonrobert", "username": "johnsonrobert", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#shannon11", "username": "shannon11", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#ricky31", "username": "ricky31", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#xlucero", "username": "xlucero", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#f25030b7-5db0-44d5-ae76-4d310ef24e08", "SK": "USER#amber24", "username": "amber24", "game_id": "f25030b7-5db0-44d5-ae76-4d310ef24e08"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#mayrebecca", "username": "mayrebecca", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#roberthill", "username": "roberthill", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#emccoy", "username": "emccoy", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#maryharris", "username": "maryharris", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#iherrera", "username": "iherrera", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#emma83", "username": "emma83", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#deanmcclure", "username": "deanmcclure", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#robertwood", "username": "robertwood", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#nruiz", "username": "nruiz", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#branchmichael", "username": "branchmichael", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#lisabaker", "username": "lisabaker", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#waltervargas", "username": "waltervargas", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#jeremyjohnson", "username": "jeremyjohnson", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#richardbowman", "username": "richardbowman", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#meghanhernandez", "username": "meghanhernandez", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#pboyd", "username": "pboyd", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}
+{"PK": "GAME#3d4285f0-e52b-401a-a59b-112b38c4a26b", "SK": "USER#victoriapatrick", "username": "victoriapatrick", "game_id": "3d4285f0-e52b-401a-a59b-112b38c4a26b"}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- The battle-royale.zip did not have the JSON file to load items. As part of this PR we should ensure the code in the ZIP does match the lab guide, and that the ZIP correctly unpacks with the expected tree structure.
On unzip, we have a folder named scripts with these contents:
```
% tree public/assets/scripts 
public/assets/scripts
├── add_inverted_index.py
├── add_secondary_index.py
├── bulk_load_table.py
├── create_table.py
├── delete_table.py
├── entities.py
├── fetch_game_and_players.py
├── find_games_for_user.py
├── find_open_games.py
├── find_open_games_by_map.py
├── items.json
├── join_game.py
└── start_game.py

1 directory, 13 files
```

Note that the old battle-royale.tar had a separate application/ folder but we have put all files in the scripts folder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
