### PR TITLE
Update C9.yaml to address bug in error handling for C9 Instance Finder

### DIFF
--- a/design-patterns/cloudformation/C9.yaml
+++ b/design-patterns/cloudformation/C9.yaml
@@ -318,7 +318,7 @@ Resources:
                       print(err)
                       status = cfnresponse.FAILED
                       print(traceback.format_exc())
-                      responseData = {'Error': traceback.format_exc(err)}
+                      responseData = {'Error': traceback.format_exc()}
                   finally:
                       cfnresponse.send(event, context, status, responseData, 'CustomResourcePhysicalID')
                       


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Addresses the following failure with exception handling. We should not pass `err` object to the traceback function
>[ERROR] TypeError: '>=' not supported between instances of 'IndexError' and 'int'
Traceback (most recent call last):
  File "/var/task/index.py", line 53, in lambda_handler
    responseData = {'Error': traceback.format_exc(err)}
  File "/var/lang/lib/python3.9/traceback.py", line 167, in format_exc
    return "".join(format_exception(*sys.exc_info(), limit=limit, chain=chain))
  File "/var/lang/lib/python3.9/traceback.py", line 120, in format_exception
    return list(TracebackException(
  File "/var/lang/lib/python3.9/traceback.py", line 517, in _init
    self.stack = StackSummary.extract(
  File "/var/lang/lib/python3.9/traceback.py", line 340, in extract
    if limit >= 0:_

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
