### PR TITLE
Adding TOKEN as header to curl command for INSTANCE_ROLE and Region

### DIFF
--- a/static/files/dynamodb-opensearch-zetl/OpenSearchPipeline/credentials.sh
+++ b/static/files/dynamodb-opensearch-zetl/OpenSearchPipeline/credentials.sh
@@ -1,10 +1,10 @@
 TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-INSTANCE_ROLE=$(curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/)
+INSTANCE_ROLE=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/)
 RESULTS=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/${INSTANCE_ROLE})
 
 AccessKeyId=$(echo $RESULTS | jq -r '.AccessKeyId')
 SecretAccessKey=$(echo $RESULTS | jq -r '.SecretAccessKey')
-Region=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/\(.*\)[a-z]/\1/')
+Region=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/\(.*\)[a-z]/\1/')
 Token=$(echo $RESULTS | jq -r '.Token')
 Role=$(aws sts get-caller-identity | jq -r '.Arn | sub("sts";"iam") | sub("assumed-role";"role") | sub("/i-[a-zA-Z0-9]+$";"")')
 


### PR DESCRIPTION
*Issue #, if available:*
credential.sh was failing to set INSTANCE_ROLE and Region env variables
*Description of changes:*
Adding TOKEN as header to curl command for INSTANCE_ROLE and Region

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
